### PR TITLE
Prepare the switch to big query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ src_managed/
 project/boot/
 .history
 .cache
+src/main/resources/service-account.json

--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,7 @@ libraryDependencies ++= Seq(
   "org.scalikejdbc" %% "scalikejdbc-config" % "3.5.0",
   "com.zaneli" %% "scalikejdbc-athena" % "0.2.4",
   "com.syncron.amazonaws" % "simba-athena-jdbc-driver" % "2.0.2",
+  "com.google.cloud" % "google-cloud-bigquery" % "1.116.10",
   "org.scalatest" %% "scalatest" % "3.2.0" % "test",
   "io.circe" %% "circe-core" % "0.12.3",
   "io.circe" %% "circe-generic" % "0.12.3",

--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.TimeUnit
 
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
 import com.amazonaws.services.sqs.model.SendMessageResult
-import com.gu.newsletterlistcleanse.db.{AthenaOperations, BigQueryOperations, DatabaseOperations}
+import com.gu.newsletterlistcleanse.db.{BigQueryOperations, DatabaseOperations}
 import com.gu.newsletterlistcleanse.models.{CleanseList, NewsletterCutOff}
 import com.gu.newsletterlistcleanse.sqs.AwsSQSSend
 import com.gu.newsletterlistcleanse.sqs.AwsSQSSend.{Payload, QueueName}

--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.TimeUnit
 
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
 import com.amazonaws.services.sqs.model.SendMessageResult
-import com.gu.newsletterlistcleanse.db.{Campaigns, CampaignsFromDB}
+import com.gu.newsletterlistcleanse.db.{AthenaOperations, DatabaseOperations}
 import com.gu.newsletterlistcleanse.models.{CleanseList, NewsletterCutOff}
 import com.gu.newsletterlistcleanse.sqs.AwsSQSSend
 import com.gu.newsletterlistcleanse.sqs.AwsSQSSend.{Payload, QueueName}
@@ -23,7 +23,7 @@ import scala.concurrent.{Await, Future}
 object GetCleanseListLambda {
 
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
-  val campaigns: Campaigns = new CampaignsFromDB()
+  val campaigns: DatabaseOperations = new AthenaOperations()
 
   val timeout: Duration = Duration(15, TimeUnit.MINUTES)
 

--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
@@ -23,7 +23,7 @@ import scala.concurrent.{Await, Future}
 object GetCleanseListLambda {
 
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
-  val campaigns: DatabaseOperations = new AthenaOperations()
+  val databaseOperations: DatabaseOperations = new AthenaOperations()
 
   val timeout: Duration = Duration(15, TimeUnit.MINUTES)
 
@@ -56,7 +56,7 @@ object GetCleanseListLambda {
 
     val results = for {
       campaignCutOff <- campaignCutOffDates
-      userIds = campaigns.fetchCampaignCleanseList(campaignCutOff).map(_.userId)
+      userIds = databaseOperations.fetchCampaignCleanseList(campaignCutOff).map(_.userId)
       cleanseList = CleanseList(
         campaignCutOff.newsletterName,
         userIds

--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCutOffDatesLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCutOffDatesLambda.scala
@@ -1,11 +1,10 @@
 package com.gu.newsletterlistcleanse
 
-import java.io.FileInputStream
 import java.util.concurrent.TimeUnit
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.sqs.model.SendMessageResult
-import com.gu.newsletterlistcleanse.db.{BigQueryOperations, DatabaseOperations}
+import com.gu.newsletterlistcleanse.db.{AthenaOperations, DatabaseOperations}
 import com.gu.newsletterlistcleanse.models.NewsletterCutOff
 import com.gu.newsletterlistcleanse.sqs.AwsSQSSend
 import com.gu.newsletterlistcleanse.sqs.AwsSQSSend.{Payload, QueueName}
@@ -25,7 +24,7 @@ case class GetCutOffDatesLambdaInput(
 class GetCutOffDatesLambda {
 
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
-  val campaigns: DatabaseOperations = new BigQueryOperations(new FileInputStream("abc.json")) // TODO load this from SSM / local for dev
+  val campaigns: DatabaseOperations = new AthenaOperations()
   val newsletters: Newsletters = new Newsletters()
 
   val timeout: Duration = Duration(15, TimeUnit.MINUTES)

--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCutOffDatesLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCutOffDatesLambda.scala
@@ -1,10 +1,11 @@
 package com.gu.newsletterlistcleanse
 
+import java.io.InputStream
 import java.util.concurrent.TimeUnit
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.sqs.model.SendMessageResult
-import com.gu.newsletterlistcleanse.db.{AthenaOperations, DatabaseOperations}
+import com.gu.newsletterlistcleanse.db.{BigQueryOperations, DatabaseOperations}
 import com.gu.newsletterlistcleanse.models.NewsletterCutOff
 import com.gu.newsletterlistcleanse.sqs.AwsSQSSend
 import com.gu.newsletterlistcleanse.sqs.AwsSQSSend.{Payload, QueueName}
@@ -15,6 +16,7 @@ import scala.beans.BeanProperty
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.io.Source
 
 case class GetCutOffDatesLambdaInput(
   @BeanProperty
@@ -24,7 +26,8 @@ case class GetCutOffDatesLambdaInput(
 class GetCutOffDatesLambda {
 
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
-  val databaseOperations: DatabaseOperations = new AthenaOperations()
+  val serviceAccountCredentials: InputStream = this.getClass.getClassLoader().getResource("service-account.json").openStream()
+  val databaseOperations: DatabaseOperations = new BigQueryOperations(serviceAccountCredentials)
   val newsletters: Newsletters = new Newsletters()
 
   val timeout: Duration = Duration(15, TimeUnit.MINUTES)

--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCutOffDatesLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCutOffDatesLambda.scala
@@ -1,10 +1,11 @@
 package com.gu.newsletterlistcleanse
 
+import java.io.FileInputStream
 import java.util.concurrent.TimeUnit
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.sqs.model.SendMessageResult
-import com.gu.newsletterlistcleanse.db.{Campaigns, CampaignsFromDB}
+import com.gu.newsletterlistcleanse.db.{BigQueryOperations, DatabaseOperations}
 import com.gu.newsletterlistcleanse.models.NewsletterCutOff
 import com.gu.newsletterlistcleanse.sqs.AwsSQSSend
 import com.gu.newsletterlistcleanse.sqs.AwsSQSSend.{Payload, QueueName}
@@ -21,10 +22,10 @@ case class GetCutOffDatesLambdaInput(
   newslettersToProcess: List[String]
 )
 
-object GetCutOffDatesLambda {
+class GetCutOffDatesLambda {
 
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
-  val campaigns: Campaigns = new CampaignsFromDB()
+  val campaigns: DatabaseOperations = new BigQueryOperations(new FileInputStream("abc.json")) // TODO load this from SSM / local for dev
   val newsletters: Newsletters = new Newsletters()
 
   val timeout: Duration = Duration(15, TimeUnit.MINUTES)
@@ -57,7 +58,8 @@ object GetCutOffDatesLambda {
 
 object TestGetCutOffDates {
   def main(args: Array[String]): Unit = {
+    val getCutOffDatesLambda = new GetCutOffDatesLambda()
     val lambdaInput = GetCutOffDatesLambdaInput(List("Editorial_AnimalsFarmed", "Editorial_TheLongRead"))
-    Await.result(GetCutOffDatesLambda.process(lambdaInput), GetCutOffDatesLambda.timeout)
+    Await.result(getCutOffDatesLambda.process(lambdaInput), getCutOffDatesLambda.timeout)
   }
 }

--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCutOffDatesLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCutOffDatesLambda.scala
@@ -24,7 +24,7 @@ case class GetCutOffDatesLambdaInput(
 class GetCutOffDatesLambda {
 
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
-  val campaigns: DatabaseOperations = new AthenaOperations()
+  val databaseOperations: DatabaseOperations = new AthenaOperations()
   val newsletters: Newsletters = new Newsletters()
 
   val timeout: Duration = Duration(15, TimeUnit.MINUTES)
@@ -47,7 +47,7 @@ class GetCutOffDatesLambda {
     logger.info(s"Starting $env")
     val newslettersToProcess = Option(lambdaInput.newslettersToProcess) // this is set by AWS, so potentially null
       .getOrElse(newsletters.allNewsletters)
-    val campaignSentDates = campaigns.fetchCampaignSentDates(newslettersToProcess, Newsletters.maxCutOffPeriod)
+    val campaignSentDates = databaseOperations.fetchCampaignSentDates(newslettersToProcess, Newsletters.maxCutOffPeriod)
     val cutOffDates = newsletters.computeCutOffDates(campaignSentDates)
     logger.info(s"result: ${cutOffDates.asJson.noSpaces}")
     val queueName = QueueName(s"newsletter-newsletter-cut-off-date-${env.stage}")

--- a/src/main/scala/com/gu/newsletterlistcleanse/NewsletterAWSCredentialProvider.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/NewsletterAWSCredentialProvider.scala
@@ -1,7 +1,7 @@
 package com.gu.newsletterlistcleanse
 
-import com.simba.athena.amazonaws.auth.{ AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain }
-import com.simba.athena.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.auth.{AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain}
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
 
 class NewsletterAWSCredentialProvider extends AWSCredentialsProviderChain(
   new ProfileCredentialsProvider("ophan"),

--- a/src/main/scala/com/gu/newsletterlistcleanse/db/AthenaOperations.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/db/AthenaOperations.scala
@@ -1,19 +1,12 @@
 package com.gu.newsletterlistcleanse.db
 
-import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
 import com.gu.newsletterlistcleanse.models.NewsletterCutOff
 import scalikejdbc._
 import scalikejdbc.athena._
 
-trait Campaigns {
-  def fetchCampaignSentDates(campaignNames: List[String], cutOffLength: Int): List[CampaignSentDate]
-
-  def fetchCampaignCleanseList(newsletterCutOff: NewsletterCutOff): List[UserID]
-}
-
-class CampaignsFromDB extends Campaigns {
+class AthenaOperations extends DatabaseOperations {
   override def fetchCampaignSentDates(campaignNames: List[String], cutOffLength: Int): List[CampaignSentDate] = {
     DB.athena { implicit session =>
       sql"""

--- a/src/main/scala/com/gu/newsletterlistcleanse/db/BigQueryOperations.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/db/BigQueryOperations.scala
@@ -1,0 +1,67 @@
+package com.gu.newsletterlistcleanse.db
+
+import java.io.InputStream
+import java.time.{Instant, ZoneId, ZonedDateTime}
+
+import com.gu.newsletterlistcleanse.models.NewsletterCutOff
+import com.google.cloud.bigquery.{BigQuery, BigQueryOptions, QueryJobConfiguration, QueryParameterValue}
+import com.google.auth.Credentials
+import com.google.auth.oauth2.ServiceAccountCredentials
+
+import scala.collection.JavaConverters._
+
+class BigQueryOperations(googleCredentials: InputStream) extends DatabaseOperations {
+
+  val credentials: Credentials = ServiceAccountCredentials
+    .fromStream(googleCredentials)
+    .toBuilder
+    .setScopes(List("https://www.googleapis.com/auth/bigquery").asJavaCollection)
+    .build()
+
+  val bigQuery: BigQuery = BigQueryOptions
+    .newBuilder()
+    .setCredentials(credentials)
+    .setProjectId("datatech-platform-code")
+    .build()
+    .getService
+
+  private def toUTCZonedDateTime(epochMicro: Long): ZonedDateTime = {
+    ZonedDateTime.ofInstant(Instant.ofEpochMilli(epochMicro / 1000), ZoneId.of("UTC"))
+  }
+
+  override def fetchCampaignSentDates(campaignNames: List[String], cutOffLength: Int): List[CampaignSentDate] = {
+
+    val sql = """SELECT campaign_name, campaign_id, timestamp FROM (
+                |  SELECT row_number() over(PARTITION BY campaign_name) AS rn, *
+                |  FROM (
+                |    SELECT
+                |      campaign_name,
+                |      campaign_id,
+                |      timestamp
+                |    FROM
+                |      `clean.braze_dispatch`
+                |    WHERE campaign_name IN UNNEST(@campaignNames)
+                |    ORDER BY timestamp DESC
+                |  )
+                |)
+                |WHERE rn <= @cutOffLength""".stripMargin
+
+    val queryConfig = QueryJobConfiguration.newBuilder(sql)
+      .addNamedParameter("campaignNames", QueryParameterValue.array(campaignNames.toArray, classOf[String]))
+      .addNamedParameter("cutOffLength", QueryParameterValue.int64(94L))
+      .setUseLegacySql(false)
+      .build()
+
+    val results = bigQuery.query(queryConfig)
+
+    results.iterateAll().asScala.toList.map { result =>
+      CampaignSentDate(
+        campaignId = result.get("campaign_id").getStringValue,
+        campaignName = result.get("campaign_name").getStringValue,
+        timestamp = toUTCZonedDateTime(result.get("timestamp").getTimestampValue)
+      )
+    }
+  }
+
+  override def fetchCampaignCleanseList(newsletterCutOff: NewsletterCutOff): List[UserID] = ???
+}

--- a/src/main/scala/com/gu/newsletterlistcleanse/db/DatabaseOperations.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/db/DatabaseOperations.scala
@@ -1,0 +1,11 @@
+package com.gu.newsletterlistcleanse.db
+
+import com.gu.newsletterlistcleanse.models.NewsletterCutOff
+
+trait DatabaseOperations {
+  def fetchCampaignSentDates(campaignNames: List[String], cutOffLength: Int): List[CampaignSentDate]
+
+  def fetchCampaignCleanseList(newsletterCutOff: NewsletterCutOff): List[UserID]
+}
+
+


### PR DESCRIPTION
This refactors the database layer to handle two backends: Athena and Bigquery.

We then provided an example implementation for one the queries using Bigquery, pending test with valid credentials to confirm it works. The implementation isn't complete and was an attempt to understand how much work it would be to switch from one to the other, however we're currently blocked for administrative reasons rather than technical reasons. We believe there's value in getting this merged anyway to simplify the move to bigquery.

Once we've validated it works, we can switch from one backend to the other by swapping the use of `AthenaOperations` with `BigQueryOperations`

co-authored with @buck06191 