### PR TITLE
🚧 ⚡️ Improve EitherList utility function

### DIFF
--- a/src/main/scala/com/gu/newsletterlistcleanse/EitherConverter.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/EitherConverter.scala
@@ -3,18 +3,61 @@ package com.gu.newsletterlistcleanse
 import scala.annotation.tailrec
 
 object EitherConverter {
-    implicit class EitherList[E, A](le: List[Either[E, A]]){
-      def toEitherList: Either[E, List[A]] = {
-        @tailrec
-        def helper(list: List[Either[E, A]], acc: List[A]):
-        Either[E, List[A]] = list match {
-          case Nil => Right(acc)
-          case x::xs => x match {
-            case Left(e) => Left(e)
-            case Right(v) => helper(xs, acc :+ v)
+  implicit class EitherList[E, A](le: List[Either[E, A]]){
+    def toEitherList: Either[List[E], List[A]] = {
+      @tailrec
+      def helper(list: List[Either[E, A]], acc: Either[List[E], List[A]]): Either[List[E], List[A]] =
+        list match {
+          case Nil => acc
+          case x :: xs => x match {
+            case Left(e) => {
+              acc match {
+                case Left(es) => helper(xs, Left(e :: es))
+                case Right(_) => helper(xs, Left(List(e)) )
+              }
+            }
+            case Right(a) => {
+              acc match {
+                case Left(es) => helper(xs, Left(es))
+                case Right(as) => helper(xs, Right(a :: as))
+              }
+            }
           }
         }
-        helper(le, Nil)
+      helper(le.reverse, Right(Nil))
+    }
+
+    def toEitherListFold: Either[List[E], List[A]] = {
+      le.foldRight[Either[List[E], List[A]]](Right(Nil)) { (ea, acc) =>
+        ea match {
+          case Left(e) => {
+            acc match {
+              case Left(es) => Left(e :: es)
+              case Right(_) => Left(List(e))
+            }
+          }
+          case Right(a) => {
+            acc match {
+              case Left(es) => Left(es)
+              case Right(as) => Right(a :: as)
+            }
+          }
+        }
       }
     }
+
+    def toEitherListFold2: Either[List[E], List[A]] = {
+      le.foldRight[Either[List[E], List[A]]](Right(Nil)) {
+        case (Left(e), Left(es)) =>
+          Left(e :: es)
+        case (Left(e), Right(_)) =>
+          Left(List(e)) // Throw away accumulated successes and only track errors
+        case (Right(_), Left(es)) =>
+          Left(es)
+        case (Right(a), Right(as)) =>
+          Right(a :: as) // Keep accumulating successes
+      }
+    }
+
+  }
 }

--- a/src/main/scala/com/gu/newsletterlistcleanse/EitherConverter.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/EitherConverter.scala
@@ -1,61 +1,13 @@
 package com.gu.newsletterlistcleanse
 
-import scala.annotation.tailrec
-
 object EitherConverter {
   implicit class EitherList[E, A](le: List[Either[E, A]]){
     def toEitherList: Either[List[E], List[A]] = {
-      @tailrec
-      def helper(list: List[Either[E, A]], acc: Either[List[E], List[A]]): Either[List[E], List[A]] =
-        list match {
-          case Nil => acc
-          case x :: xs => x match {
-            case Left(e) => {
-              acc match {
-                case Left(es) => helper(xs, Left(e :: es))
-                case Right(_) => helper(xs, Left(List(e)) )
-              }
-            }
-            case Right(a) => {
-              acc match {
-                case Left(es) => helper(xs, Left(es))
-                case Right(as) => helper(xs, Right(a :: as))
-              }
-            }
-          }
-        }
-      helper(le.reverse, Right(Nil))
-    }
-
-    def toEitherListFold: Either[List[E], List[A]] = {
-      le.foldRight[Either[List[E], List[A]]](Right(Nil)) { (ea, acc) =>
-        ea match {
-          case Left(e) => {
-            acc match {
-              case Left(es) => Left(e :: es)
-              case Right(_) => Left(List(e))
-            }
-          }
-          case Right(a) => {
-            acc match {
-              case Left(es) => Left(es)
-              case Right(as) => Right(a :: as)
-            }
-          }
-        }
-      }
-    }
-
-    def toEitherListFold2: Either[List[E], List[A]] = {
       le.foldRight[Either[List[E], List[A]]](Right(Nil)) {
-        case (Left(e), Left(es)) =>
-          Left(e :: es)
-        case (Left(e), Right(_)) =>
-          Left(List(e)) // Throw away accumulated successes and only track errors
-        case (Right(_), Left(es)) =>
-          Left(es)
-        case (Right(a), Right(as)) =>
-          Right(a :: as) // Keep accumulating successes
+        case (Left(e), Left(es)) => Left(e :: es)
+        case (Left(e), Right(_)) => Left(List(e))
+        case (Right(_), Left(es)) => Left(es)
+        case (Right(a), Right(as)) => Right(a :: as)
       }
     }
 

--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
@@ -31,12 +31,12 @@ object GetCleanseListLambda {
     parseSqsMessage(sqsEvent) match {
       case Right(cleanseLists) =>
         Await.result(process(cleanseLists), timeout)
-      case Left(parseError) =>
-        logger.error(parseError.getMessage)
+      case Left(parseErrors) =>
+        parseErrors.foreach(e => logger.error(e.getMessage))
     }
   }
 
-  def parseSqsMessage(sqsEvent: SQSEvent): Either[circe.Error, List[NewsletterCutOff]] = {
+  def parseSqsMessage(sqsEvent: SQSEvent): Either[List[circe.Error], List[NewsletterCutOff]] = {
     (for {
       message <- sqsEvent.getRecords.asScala.toList
     } yield {

--- a/src/test/scala/com/gu/newsletterlistcleanse/EitherConverterTest.scala
+++ b/src/test/scala/com/gu/newsletterlistcleanse/EitherConverterTest.scala
@@ -1,0 +1,34 @@
+package com.gu.newsletterlistcleanse
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import com.gu.newsletterlistcleanse.EitherConverter.EitherList
+
+
+class EitherConverterTest extends AnyFlatSpec with Matchers {
+
+  "The EitherList converter" should "return a Right with a list of successes if no errors occurred" in {
+
+    val l: List[Either[Error, String]] = List(Right("a"), Right("b"), Right("c"))
+
+    val result = l.toEitherList
+
+    result should be(Right(List("a", "b", "c")))
+  }
+
+  it should "return a Left even if only one error occurs" in {
+    val testErrorB: Error = new Error("b")
+    val l: List[Either[Error, String]] = List(Right("a"), Left(testErrorB), Right("c"))
+
+    l.toEitherList should be(Left(List(testErrorB)))
+  }
+
+  it should "return a Left with a list of all errors if more than one error occurred" in {
+    val testErrorA: Error = new Error("a")
+    val testErrorB: Error = new Error("b")
+    val l: List[Either[Error, String]] = List(Left(testErrorA), Left(testErrorB), Right("c"))
+
+    l.toEitherList should be(Left(List(testErrorA, testErrorB)))
+  }
+}


### PR DESCRIPTION
## What does this change?
Prior to this, the `toEitherList` utility function returned the first Error it encountered in the list of `Either`s, meaning we were throwing away data we may have wanted to keep. 

I've modified it here to return a list of Errors rather than the first one that occurs.

Note: Three alternative methods are presented here with the intention to remove all but the chosen one.

## How to test
`sbt test`

Unit tests are present.

