### PR TITLE
Implement updateBrazeUsers lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ runMain com.gu.newsletterlistcleanse.TestGetCleanseList
 
 ```sbtshell
 eval System.setProperty("Stage", "CODE")
-runMain com.gu.newsletterlistcleanse.UpdateBrazeUsersLambda
+runMain com.gu.newsletterlistcleanse.TestUpdateBrazeUsers
 ```
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,8 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.2.0" % "test",
   "io.circe" %% "circe-core" % "0.12.3",
   "io.circe" %% "circe-generic" % "0.12.3",
-  "io.circe" %% "circe-parser"% "0.12.3"
+  "io.circe" %% "circe-parser"% "0.12.3",
+  "org.scalaj" %% "scalaj-http" % "2.4.2"
 )
 assemblyJarName := s"${name.value}.jar"
 assemblyMergeStrategy in assembly := {

--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
@@ -28,15 +28,16 @@ object GetCleanseListLambda {
   val timeout: Duration = Duration(15, TimeUnit.MINUTES)
 
   def handler(sqsEvent: SQSEvent): Unit = {
-    parseSqsMessage(sqsEvent) match {
-      case Right(cleanseLists) =>
-        Await.result(process(cleanseLists), timeout)
+    parseCutoffsSqsMessage(sqsEvent) match {
+      case Right(newsletterCutOffs) =>
+        Await.result(process(newsletterCutOffs), timeout)
       case Left(parseErrors) =>
-        parseErrors.foreach(e => logger.error(e.getMessage))
+        parseErrors.forEach(e =>logger.error(e.getMessage))
     }
   }
 
-  def parseSqsMessage(sqsEvent: SQSEvent): Either[List[circe.Error], List[NewsletterCutOff]] = {
+  // TODO: Convert this to a generic function for use here and in UpdateBrazeUsers
+  def parseCutoffsSqsMessage(sqsEvent: SQSEvent): Either[circe.Error, List[NewsletterCutOff]] = {
     (for {
       message <- sqsEvent.getRecords.asScala.toList
     } yield {

--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
@@ -32,12 +32,12 @@ object GetCleanseListLambda {
       case Right(newsletterCutOffs) =>
         Await.result(process(newsletterCutOffs), timeout)
       case Left(parseErrors) =>
-        parseErrors.forEach(e =>logger.error(e.getMessage))
+        parseErrors.foreach(e =>logger.error(e.getMessage))
     }
   }
 
   // TODO: Convert this to a generic function for use here and in UpdateBrazeUsers
-  def parseCutoffsSqsMessage(sqsEvent: SQSEvent): Either[circe.Error, List[NewsletterCutOff]] = {
+  def parseCutoffsSqsMessage(sqsEvent: SQSEvent): Either[List[circe.Error], List[NewsletterCutOff]] = {
     (for {
       message <- sqsEvent.getRecords.asScala.toList
     } yield {

--- a/src/main/scala/com/gu/newsletterlistcleanse/Newsletters.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/Newsletters.scala
@@ -2,7 +2,7 @@ package com.gu.newsletterlistcleanse
 
 import java.time.ZonedDateTime
 
-import com.gu.identity.model.EmailNewsletters
+import com.gu.identity.model.{EmailNewsletter, EmailNewsletters}
 import com.gu.newsletterlistcleanse.db.CampaignSentDate
 import com.gu.newsletterlistcleanse.models.NewsletterCutOff
 
@@ -141,4 +141,8 @@ object Newsletters {
   )
 
   val newsletterToAttribute: Map[String, String] = attributeToNewsletterMapping.map(_.swap)
+
+  def getIdentityNewsletterFromName(newsletterName: String): Option[EmailNewsletter] =
+    Option(Newsletters.newsletterToAttribute(newsletterName)).flatMap(
+      name => EmailNewsletters.frombrazeSubscribeAttributeName(name))
 }

--- a/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
@@ -45,7 +45,7 @@ object UpdateBrazeUsersLambda {
     }).toEitherList
   }
 
-  def process(cleanseLists: List[CleanseList]): Either[List[BrazeError], List[BrazeResponse]] = {
+  def process(cleanseLists: List[CleanseList]): Unit = { //Either[List[BrazeError], List[BrazeResponse]] = {
 
     val brazeResponses = for {
       cleanseList <- cleanseLists
@@ -64,14 +64,14 @@ object UpdateBrazeUsersLambda {
       BrazeClient.updateUser(apiKey, request)
     }
 
-    brazeResponses.toEitherList
+//    brazeResponses.toEitherList
 
   }
 }
 
 object TestUpdateBrazeUsers {
   def main(args: Array[String]): Unit = {
-//    cleanseLists= List(CleanseList())
-//    println(UpdateBrazeUsersLambda.process())
+    val cleanseLists= List(CleanseList("Editorial_AnimalsFarmed", List("user_1", "user_2")))
+    println(UpdateBrazeUsersLambda.process(cleanseLists))
   }
 }

--- a/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
@@ -1,16 +1,18 @@
 package com.gu.newsletterlistcleanse
 
+import java.time.format.DateTimeFormatter
+import java.time.{Instant, ZoneId, ZonedDateTime}
 import java.util.concurrent.TimeUnit
 
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
 import com.gu.newsletterlistcleanse.EitherConverter.EitherList
-import com.gu.newsletterlistcleanse.GetCleanseListLambda.{logger, parseCutoffsSqsMessage, process, timeout}
-import com.gu.newsletterlistcleanse.braze.BrazeClient
+import com.gu.newsletterlistcleanse.Newsletters.getIdentityNewsletterFromName
+import com.gu.newsletterlistcleanse.braze.{BrazeClient, BrazeError, BrazeNewsletterSubscriptionsUpdate, BrazeResponse, UserTrackRequest}
 import com.gu.newsletterlistcleanse.models.CleanseList
 import io.circe
 import io.circe.parser.decode
 import org.slf4j.{Logger, LoggerFactory}
-import scalaj.http.HttpResponse
+
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Await
@@ -23,22 +25,19 @@ object UpdateBrazeUsersLambda {
 
   val timeout: Duration = Duration(15, TimeUnit.MINUTES)
 
-  val brazeClient: BrazeClient = new BrazeClient()
-
-
   def handler(sqsEvent: SQSEvent): Unit = {
     val env = Env()
     logger.info(s"Starting $env")
     parseCleanseListSqsMessage(sqsEvent) match {
       case Right(cleanseLists) =>
         process(cleanseLists)
-      case Left(parseError) =>
-        logger.error(parseError.getMessage)
+      case Left(parseErrors) =>
+        parseErrors.foreach(e => logger.error(e.getMessage))
     }
 
   }
 
-  def parseCleanseListSqsMessage(sqsEvent: SQSEvent): Either[circe.Error, List[CleanseList]] = {
+  def parseCleanseListSqsMessage(sqsEvent: SQSEvent): Either[List[circe.Error], List[CleanseList]] = {
     (for {
       message <- sqsEvent.getRecords.asScala.toList
     } yield {
@@ -46,24 +45,33 @@ object UpdateBrazeUsersLambda {
     }).toEitherList
   }
 
-  def process(cleanseLists: List[CleanseList]): Either[Error, List[HttpResponse[String]]] = {
+  def process(cleanseLists: List[CleanseList]): Either[List[BrazeError], List[BrazeResponse]] = {
 
-    for {
+    val brazeResponses = for {
       cleanseList <- cleanseLists
       newsletterName = cleanseList.newsletterName
       userIds = cleanseList.userIdList
-    } {
-      ???
-      // TODO: Create API request
+      userId <- userIds
+      identityNewsletter <- getIdentityNewsletterFromName(newsletterName)
+    } yield {
 
-      // TODO: Send API request
+      val apiKey: String = Option(System.getenv("BRAZE_API_KEY")).getOrElse("")
+      val timestamp: Instant = ZonedDateTime.now(ZoneId.of("UTC")).toInstant
+      val subscriptionsUpdate = BrazeNewsletterSubscriptionsUpdate(userId, Map((identityNewsletter, false)))
+
+      val request: UserTrackRequest = UserTrackRequest.apply(subscriptionsUpdate, timestamp)
+
+      BrazeClient.updateUser(apiKey, request)
     }
+
+    brazeResponses.toEitherList
 
   }
 }
 
 object TestUpdateBrazeUsers {
   def main(args: Array[String]): Unit = {
-    println(UpdateBrazeUsersLambda.process(args.headOption.getOrElse("Alex"), Env()))
+//    cleanseLists= List(CleanseList())
+//    println(UpdateBrazeUsersLambda.process())
   }
 }

--- a/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
@@ -45,7 +45,7 @@ object UpdateBrazeUsersLambda {
     }).toEitherList
   }
 
-  def process(cleanseLists: List[CleanseList]): Unit = { //Either[List[BrazeError], List[BrazeResponse]] = {
+  def process(cleanseLists: List[CleanseList]): Either[List[BrazeError], List[BrazeResponse]] = {
 
     val brazeResponses = for {
       cleanseList <- cleanseLists
@@ -64,14 +64,14 @@ object UpdateBrazeUsersLambda {
       BrazeClient.updateUser(apiKey, request)
     }
 
-//    brazeResponses.toEitherList
+    brazeResponses.toEitherList
 
   }
 }
 
 object TestUpdateBrazeUsers {
   def main(args: Array[String]): Unit = {
-    val cleanseLists= List(CleanseList("Editorial_AnimalsFarmed", List("user_1", "user_2")))
+    val cleanseLists= List(CleanseList("Editorial_AnimalsFarmed", List("user_1_jrb", "user_2_jrb")))
     println(UpdateBrazeUsersLambda.process(cleanseLists))
   }
 }

--- a/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
@@ -1,36 +1,65 @@
 package com.gu.newsletterlistcleanse
 
-import com.amazonaws.services.lambda.runtime.Context
-import org.slf4j.{ Logger, LoggerFactory }
+import java.util.concurrent.TimeUnit
 
-/**
- * This is compatible with aws' lambda JSON to POJO conversion.
- * You can test your lambda by sending it the following payload:
- * {"name": "Bob"}
- */
-class UpdateBrazeUsersLambdaInput() {
-  var name: String = _
-  def getName(): String = name
-  def setName(theName: String): Unit = name = theName
-}
+import com.amazonaws.services.lambda.runtime.events.SQSEvent
+import com.gu.newsletterlistcleanse.EitherConverter.EitherList
+import com.gu.newsletterlistcleanse.GetCleanseListLambda.{logger, parseCutoffsSqsMessage, process, timeout}
+import com.gu.newsletterlistcleanse.braze.BrazeClient
+import com.gu.newsletterlistcleanse.models.CleanseList
+import io.circe
+import io.circe.parser.decode
+import org.slf4j.{Logger, LoggerFactory}
+import scalaj.http.HttpResponse
+
+import scala.collection.JavaConverters._
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
 
 object UpdateBrazeUsersLambda {
 
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
-  /*
-   * This is your lambda entry point
-   */
-  def handler(lambdaInput: UpdateBrazeUsersLambdaInput, context: Context): Unit = {
+  val timeout: Duration = Duration(15, TimeUnit.MINUTES)
+
+  val brazeClient: BrazeClient = new BrazeClient()
+
+
+  def handler(sqsEvent: SQSEvent): Unit = {
     val env = Env()
     logger.info(s"Starting $env")
-    logger.info(process(lambdaInput.name, env))
+    parseCleanseListSqsMessage(sqsEvent) match {
+      case Right(cleanseLists) =>
+        process(cleanseLists)
+      case Left(parseError) =>
+        logger.error(parseError.getMessage)
+    }
+
   }
 
-  /*
-   * I recommend to put your logic outside of the handler
-   */
-  def process(name: String, env: Env): String = s"Hello $name! (from ${env.app} in ${env.stack})\n"
+  def parseCleanseListSqsMessage(sqsEvent: SQSEvent): Either[circe.Error, List[CleanseList]] = {
+    (for {
+      message <- sqsEvent.getRecords.asScala.toList
+    } yield {
+      decode[CleanseList](message.getBody)
+    }).toEitherList
+  }
+
+  def process(cleanseLists: List[CleanseList]): Either[Error, List[HttpResponse[String]]] = {
+
+    for {
+      cleanseList <- cleanseLists
+      newsletterName = cleanseList.newsletterName
+      userIds = cleanseList.userIdList
+    } {
+      ???
+      // TODO: Create API request
+
+      // TODO: Send API request
+    }
+
+  }
 }
 
 object TestUpdateBrazeUsers {

--- a/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
@@ -56,7 +56,7 @@ object UpdateBrazeUsersLambda {
     } yield {
 
       val apiKey: String = Option(System.getenv("BRAZE_API_KEY")).getOrElse("")
-      val timestamp: Instant = ZonedDateTime.now(ZoneId.of("UTC")).toInstant
+      val timestamp: Instant = Instant.now()
       val subscriptionsUpdate = BrazeNewsletterSubscriptionsUpdate(userId, Map((identityNewsletter, false)))
 
       val request: UserTrackRequest = UserTrackRequest.apply(subscriptionsUpdate, timestamp)

--- a/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeClient.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeClient.scala
@@ -38,18 +38,18 @@ object BrazeClient {
     }
   }
 
-  def updateUser(apiKey: String, request: UserTrackRequest): Unit = { //Either[BrazeError, BrazeResponse] = {
+  def updateUser(apiKey: String, request: UserTrackRequest): Either[BrazeError, BrazeResponse] = {
     val jsonRequest = request.asJson.toString
-    logger.info(jsonRequest)
-//    withClientLogging(s"updating user: ${request.attributes.toString()}, ${request.events.toString()}"){
-//      val response = Http(s"$brazeEndpoint/users/track")
-//        .timeout(connTimeoutMs = timeout, readTimeoutMs = timeout)
-//        .header("Content-type", "application/json")
-//        .header("Authorization", s"Bearer $apiKey")
-//        .postData(jsonRequest)
-//        .asString
-//
-//      parseValidateResponse(response)
-//    }
+    // TODO: Make logging more useful whilst maintaining data security
+    withClientLogging(s"updating user subscriptions"){
+      val response = Http(s"$brazeEndpoint/users/track")
+        .timeout(connTimeoutMs = timeout, readTimeoutMs = timeout)
+        .header("Content-type", "application/json")
+        .header("Authorization", s"Bearer $apiKey")
+        .postData(jsonRequest)
+        .asString
+
+      parseValidateResponse(response)
+    }
   }
 }

--- a/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeClient.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeClient.scala
@@ -38,16 +38,18 @@ object BrazeClient {
     }
   }
 
-  def updateUser(apiKey: String, request: UserTrackRequest): Either[BrazeError, BrazeResponse] = {
-    withClientLogging(s"updating user: ${request.attributes.toString()}, ${request.events.toString()}"){
-      val response = Http(s"$brazeEndpoint/users/track")
-        .timeout(connTimeoutMs = timeout, readTimeoutMs = timeout)
-        .header("Content-type", "application/json")
-        .header("Authorization", s"Bearer $apiKey")
-        .postData(request.asJson.noSpaces)
-        .asString
-
-      parseValidateResponse(response)
-    }
+  def updateUser(apiKey: String, request: UserTrackRequest): Unit = { //Either[BrazeError, BrazeResponse] = {
+    val jsonRequest = request.asJson.toString
+    logger.info(jsonRequest)
+//    withClientLogging(s"updating user: ${request.attributes.toString()}, ${request.events.toString()}"){
+//      val response = Http(s"$brazeEndpoint/users/track")
+//        .timeout(connTimeoutMs = timeout, readTimeoutMs = timeout)
+//        .header("Content-type", "application/json")
+//        .header("Authorization", s"Bearer $apiKey")
+//        .postData(jsonRequest)
+//        .asString
+//
+//      parseValidateResponse(response)
+//    }
   }
 }

--- a/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeClient.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeClient.scala
@@ -1,0 +1,52 @@
+package com.gu.newsletterlistcleanse.braze
+
+import org.slf4j.{Logger, LoggerFactory}
+import scalaj.http._
+import io.circe.parser.decode
+import io.circe.syntax._
+
+class BrazeClient {
+
+  private val timeout = 5000
+
+  val logger: Logger = LoggerFactory.getLogger(this.getClass)
+  val brazeEndpoint = "https://rest.fra-01.braze.eu"
+
+  private def withClientLogging[A](info: => String)(block: => Either[BrazeError,A]): Either[BrazeError, A] = {
+    val result = block
+
+    result.foreach { successResult =>
+      logger.info(s"BrazeClient success $info $successResult")
+    }
+
+    result.left.foreach { errorResult =>
+      logger.error(s"BrazeClient failure $info $errorResult")
+    }
+
+    result
+  }
+
+  private def parseValidateResponse(response: HttpResponse[String]): Either[BrazeError, BrazeResponse] = {
+    decode[BrazeResponse](response.body) match {
+      case Right(parsedResponse) if response.is2xx  =>
+        Right(parsedResponse)
+      case Left(e) if response.is2xx =>
+        logger.error("failure to parse Braze response", e)
+        Left(BrazeError(response))
+      case _ =>
+        Left(BrazeError(response))
+    }
+  }
+
+  def updateUser(request: UserTrackRequest): Either[BrazeError, BrazeResponse] = {
+    withClientLogging(s"updating user: ${request.attributes.toString()}, ${request.events.toString()}"){
+      val response = Http(s"$brazeEndpoint/users/track")
+        .timeout(connTimeoutMs = timeout, readTimeoutMs = timeout)
+        .header("Content-type", "application/json")
+        .postData(request.asJson.noSpaces)
+        .asString
+
+      parseValidateResponse(response)
+    }
+  }
+}

--- a/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeClient.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeClient.scala
@@ -5,7 +5,7 @@ import scalaj.http._
 import io.circe.parser.decode
 import io.circe.syntax._
 
-class BrazeClient {
+object BrazeClient {
 
   private val timeout = 5000
 
@@ -38,11 +38,12 @@ class BrazeClient {
     }
   }
 
-  def updateUser(request: UserTrackRequest): Either[BrazeError, BrazeResponse] = {
+  def updateUser(apiKey: String, request: UserTrackRequest): Either[BrazeError, BrazeResponse] = {
     withClientLogging(s"updating user: ${request.attributes.toString()}, ${request.events.toString()}"){
       val response = Http(s"$brazeEndpoint/users/track")
         .timeout(connTimeoutMs = timeout, readTimeoutMs = timeout)
         .header("Content-type", "application/json")
+        .header("Authorization", s"Bearer $apiKey")
         .postData(request.asJson.noSpaces)
         .asString
 

--- a/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeModels.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeModels.scala
@@ -65,13 +65,12 @@ object BrazeEvent {
 
 object BrazeSubscribeEvent {
 
-  def apply(externalId: String, sub: EmailNewsletter, isSubscribed: Boolean, timestamp: Instant, updateExistingOnlyField: Boolean = false): List[BrazeEvent] = {
+  def apply(externalId: String, sub: EmailNewsletter, timestamp: Instant, updateExistingOnlyField: Boolean = false): List[BrazeEvent] = {
     // Marketing need to be able to segment subscription events by campaign. To do this the campaign name must be in the name of the event,
     // (as braze can only segment by custom event name not property).
-    val newsletterEventName = if (isSubscribed) s"${sub.brazeSubscribeEventNamePrefix}_subscribe_email_date" else s"${sub.brazeSubscribeEventNamePrefix}_unsubscribe_email_date"
+    val newsletterEventName = s"${sub.brazeSubscribeEventNamePrefix}_unsubscribe_email_date"
 
-    val generalEventName = if (isSubscribed) "EditorialSubscribe" else "EditorialUnsubscribe"
-    // TODO: Do we need to handle subscription? Or just unsubscribe?
+    val generalEventName = "EditorialUnsubscribe"
     List(
       BrazeEvent(externalId, generalEventName, timestamp.toString, BrazeEventProperties(sub.brazeSubscribeAttributeName), updateExistingOnlyField),
       BrazeEvent(externalId, newsletterEventName, timestamp.toString, BrazeEventProperties(sub.brazeSubscribeAttributeName), updateExistingOnlyField)
@@ -84,8 +83,8 @@ case class UserTrackRequest(attributes: Seq[BrazeNewsletterSubscriptionsUpdate],
 
 object UserTrackRequest {
   def apply(userUpdate: BrazeNewsletterSubscriptionsUpdate, timestamp: Instant): UserTrackRequest = {
-    val events = userUpdate.newsletterSubscriptions.flatMap { case (subscription, isSubscribed) =>
-      BrazeSubscribeEvent(userUpdate.externalId, subscription, isSubscribed, timestamp)
+    val events = userUpdate.newsletterSubscriptions.flatMap { case (subscription, _) =>
+      BrazeSubscribeEvent(userUpdate.externalId, subscription, timestamp)
     }
     UserTrackRequest(Seq(userUpdate), events.toSeq)
   }

--- a/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeModels.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeModels.scala
@@ -30,6 +30,7 @@ object BrazeNewsletterSubscriptionsUpdate {
     new Encoder[BrazeNewsletterSubscriptionsUpdate] {
       override def apply(update: BrazeNewsletterSubscriptionsUpdate): Json = {
         val jsonSubs = update.newsletterSubscriptions.map {
+          // This case only relevant whilst migrating email_subscribe_today_uk custom attribute
           case (newsLetter: EmailNewsletter, isSubscribed) if newsLetter == EmailNewsletters.guardianTodayUk =>
             Map(
               newsLetter.brazeSubscribeAttributeName -> Json.fromBoolean(isSubscribed),
@@ -37,8 +38,8 @@ object BrazeNewsletterSubscriptionsUpdate {
             )
           case (newsLetter, isSubscribed) =>
             Map(newsLetter.brazeSubscribeAttributeName -> Json.fromBoolean(isSubscribed))
-        }
-        jsonSubs.fold(Map.empty)(_ ++ _).asJson
+        }.fold(Map.empty)(_ ++ _)
+        (jsonSubs ++ Map("external_id" -> Json.fromString(update.externalId))).asJson
       }
   }
 }

--- a/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeModels.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeModels.scala
@@ -1,0 +1,65 @@
+package com.gu.newsletterlistcleanse.braze
+
+import java.time.Instant
+
+import com.gu.identity.model.IdentityNewsletter
+import scalaj.http.HttpResponse
+import io.circe.{Encoder, Decoder}
+import io.circe.generic.semiauto.{deriveEncoder, deriveDecoder}
+
+case class BrazeResponse(message: String) {
+  def isSuccessful: Boolean = message == "success" || message == "queued"
+}
+object BrazeResponse {
+  implicit val brazeResponseEncoder: Encoder[BrazeResponse] = deriveEncoder
+  implicit val brazeResponseDecoder: Decoder[BrazeResponse] = deriveDecoder
+}
+
+case class BrazeError(code: Int, body: String)
+
+object BrazeError {
+  def apply(response: HttpResponse[String]): BrazeError = BrazeError(response.code, response.body)
+}
+
+case class BrazeNewsletterSubscriptionsUpdate(externalId: String,
+                                              newsletterSubscriptions: Map[IdentityNewsletter, Boolean])
+
+case class BrazeEventProperties(campaign_name: String)
+
+case class BrazeEvent(external_id: String,
+                      name: String,
+                      time: String,
+                      properties: BrazeEventProperties,
+                      updateExistingOnlyField: Boolean = false)
+
+object BrazeSubscribeEvent {
+
+  def apply(externalId: String, sub: IdentityNewsletter, isSubscribed: Boolean, timestamp: Instant, updateExistingOnlyField: Boolean = false): List[BrazeEvent] = {
+    // Marketing need to be able to segment subscription events by campaign. To do this the campaign name must be in the name of the event,
+    // (as braze can only segment by custom event name not property).
+    val newsletterEventName = if (isSubscribed) s"${sub.brazeSubscribeEventNamePrefix}_subscribe_email_date" else s"${sub.brazeSubscribeEventNamePrefix}_unsubscribe_email_date"
+
+    val generalEventName = if (isSubscribed) "EditorialSubscribe" else "EditorialUnsubscribe"
+
+    List(
+      BrazeEvent(externalId, generalEventName, timestamp.toString, BrazeEventProperties(sub.brazeSubscribeAttributeName), updateExistingOnlyField),
+      BrazeEvent(externalId, newsletterEventName, timestamp.toString, BrazeEventProperties(sub.brazeSubscribeAttributeName), updateExistingOnlyField)
+    )
+
+  }
+}
+
+case class UserTrackRequest(api_key: String, attributes: Seq[BrazeNewsletterSubscriptionsUpdate], events: Seq[BrazeEvent])
+
+object UserTrackRequest {
+  def apply(api_key: String, userUpdate: BrazeNewsletterSubscriptionsUpdate, timestamp: Instant): UserTrackRequest = {
+    val events = userUpdate.newsletterSubscriptions.flatMap { case (subscription, isSubscribed) =>
+      BrazeSubscribeEvent(userUpdate.externalId, subscription, isSubscribed, timestamp)
+    }
+    UserTrackRequest(api_key, Seq(userUpdate), events.toSeq)
+  }
+
+  implicit val userTrackRequestEncoder: Encoder[UserTrackRequest] = deriveEncoder
+  implicit val userTrackRequestDecoder: Decoder[UserTrackRequest] = deriveDecoder
+
+}

--- a/src/test/scala/com/gu/newsletterlistcleanse/NewslettersSpec.scala
+++ b/src/test/scala/com/gu/newsletterlistcleanse/NewslettersSpec.scala
@@ -81,4 +81,8 @@ class NewslettersSpec extends AnyFlatSpec with Matchers {
     result(1).cutOffDate should be(aDate.plusDays(999 - 61))
   }
 
+  "Requesting an EmailNewsletter from name" should "correctly return an EmailNewsletter" in {
+    val newsletterName = ""
+  }
+
 }


### PR DESCRIPTION
## What does this change?
Add a lambda to update user newsletter subscriptions in Braze using the API.

### Changes
- Add `scalaj-http` for REST requests.
- Add the data models for Braze Requests, Responses and Errors.
- Add simple Braze client for interacting with the API.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
```sbtshell
runMain com.gu.newsletterlistcleanse.TestUpdateBrazeUsers
```

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Number of "stale" users in Braze will be reduced, reducing costs.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
Need to make sure that logging doesn't expose personal information. 

