### PR TITLE
Disable daily event until we got the whole chain tested

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -211,6 +211,7 @@ Resources:
     Properties:
       Description: Event sent to process the previous day of data
       ScheduleExpression: cron(14 3 * * ? *)
+      State: DISABLED
       Targets:
         - Id: Lambda
           Arn: !GetAtt GetCutOffDatesLambda.Arn


### PR DESCRIPTION
Disable the daily event just to ensure we don't trigger the job inadvertently.