### PR TITLE
Load config from ssm

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,10 @@ scalacOptions ++= Seq(
 
 enablePlugins(RiffRaffArtifact)
 
+resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
+
 libraryDependencies ++= Seq(
+  "com.gu" %% "simple-configuration-ssm" % "1.5.2",
   "com.gu.identity" %% "identity-model" % "3.221",
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.1",
   "com.amazonaws" % "aws-lambda-java-events" % "2.2.9",

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -65,6 +65,13 @@ Resources:
               Resource:
                 - !GetAtt NewsletterCutOffDateQueue.Arn
                 - !GetAtt CleanseListQueue.Arn
+        - PolicyName: ssm
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - ssm:GetParametersByPath
+              Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${Stack}/${App}/${Stage}
 
   GetCutOffDatesLambda:
     Type: AWS::Lambda::Function

--- a/src/main/scala/com/gu/newsletterlistcleanse/Env.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/Env.scala
@@ -8,5 +8,5 @@ object Env {
   def apply(): Env = Env(
     Option(System.getenv("App")).getOrElse("DEV"),
     Option(System.getenv("Stack")).getOrElse("DEV"),
-    Option(System.getenv("Stage")).getOrElse("DEV"))
+    Option(System.getenv("Stage")).getOrElse("CODE"))
 }

--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
@@ -4,11 +4,12 @@ import java.util.concurrent.TimeUnit
 
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
+import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.amazonaws.services.sqs.model.SendMessageResult
 import com.gu.newsletterlistcleanse.db.{BigQueryOperations, DatabaseOperations}
 import com.gu.newsletterlistcleanse.models.{CleanseList, NewsletterCutOff}
 import com.gu.newsletterlistcleanse.sqs.AwsSQSSend
-import com.gu.newsletterlistcleanse.sqs.AwsSQSSend.{Payload, QueueName}
+import com.gu.newsletterlistcleanse.sqs.AwsSQSSend.Payload
 import com.gu.newsletterlistcleanse.EitherConverter.EitherList
 import io.circe
 import io.circe.parser._
@@ -26,9 +27,9 @@ class GetCleanseListLambda {
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
   val credentialProvider: AWSCredentialsProvider = new NewsletterSQSAWSCredentialProvider()
-  val sqsClient = AwsSQSSend.buildSqsClient(credentialProvider)
+  val sqsClient: AmazonSQSAsync = AwsSQSSend.buildSqsClient(credentialProvider)
   val config: NewsletterConfig = NewsletterConfig.load(credentialProvider)
-  val databaseOperations: DatabaseOperations = new BigQueryOperations(config.serviceAccount)
+  val databaseOperations: DatabaseOperations = new BigQueryOperations(config.serviceAccount, config.projectId)
 
   val timeout: Duration = Duration(15, TimeUnit.MINUTES)
 

--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
@@ -2,6 +2,7 @@ package com.gu.newsletterlistcleanse
 
 import java.util.concurrent.TimeUnit
 
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
 import com.amazonaws.services.sqs.model.SendMessageResult
 import com.gu.newsletterlistcleanse.db.{BigQueryOperations, DatabaseOperations}
@@ -23,7 +24,10 @@ import scala.concurrent.{Await, Future}
 class GetCleanseListLambda {
 
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
-  val config: NewsletterConfig = NewsletterConfig.load()
+
+  val credentialProvider: AWSCredentialsProvider = new NewsletterSQSAWSCredentialProvider()
+  val sqsClient = AwsSQSSend.buildSqsClient(credentialProvider)
+  val config: NewsletterConfig = NewsletterConfig.load(credentialProvider)
   val databaseOperations: DatabaseOperations = new BigQueryOperations(config.serviceAccount)
 
   val timeout: Duration = Duration(15, TimeUnit.MINUTES)
@@ -46,14 +50,13 @@ class GetCleanseListLambda {
     }).toEitherList
   }
 
-  def sendCleanseList(queueName: QueueName, cleanseList: CleanseList): Future[SendMessageResult] = {
-    AwsSQSSend.sendMessage(queueName, Payload(cleanseList.asJson.noSpaces))
+  def sendCleanseList(cleanseList: CleanseList): Future[SendMessageResult] = {
+    AwsSQSSend.sendMessage(sqsClient, config.cleanseListSqsUrl, Payload(cleanseList.asJson.noSpaces))
   }
 
   def process(campaignCutOffDates: List[NewsletterCutOff]): Future[List[SendMessageResult]]  = {
     val env = Env()
     logger.info(s"Starting $env")
-    val queueName = QueueName(s"newsletter-cleanse-list-${env.stage}")
 
     val results = for {
       campaignCutOff <- campaignCutOffDates
@@ -66,8 +69,8 @@ class GetCleanseListLambda {
       batchedCleanseList = cleanseList.getCleanseListBatches(5000)
       (batch, index) <- batchedCleanseList.zipWithIndex
     } yield {
-      logger.info(s"Sending batch $index of ${batch.newsletterName} to ${queueName.value}")
-      sendCleanseList(queueName, batch)
+      logger.info(s"Sending batch $index of ${batch.newsletterName}")
+      sendCleanseList(batch)
     }
 
     Future.sequence(results)

--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
@@ -1,6 +1,5 @@
 package com.gu.newsletterlistcleanse
 
-import java.io.InputStream
 import java.util.concurrent.TimeUnit
 
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
@@ -24,8 +23,8 @@ import scala.concurrent.{Await, Future}
 object GetCleanseListLambda {
 
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
-  val serviceAccountCredentials: InputStream = this.getClass.getClassLoader().getResource("service-account.json").openStream()
-  val databaseOperations: DatabaseOperations = new BigQueryOperations(serviceAccountCredentials)
+  val config: NewsletterConfig = NewsletterConfig.load()
+  val databaseOperations: DatabaseOperations = new BigQueryOperations(config.serviceAccount)
 
   val timeout: Duration = Duration(15, TimeUnit.MINUTES)
 

--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
@@ -20,7 +20,7 @@ import org.slf4j.{Logger, LoggerFactory}
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 
-object GetCleanseListLambda {
+class GetCleanseListLambda {
 
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
   val config: NewsletterConfig = NewsletterConfig.load()
@@ -78,6 +78,7 @@ object TestGetCleanseList {
   def main(args: Array[String]): Unit = {
     val json = """{"newsletterName":"Editorial_AnimalsFarmed","cutOffDate":"2020-01-21T11:31:14Z[Europe/London]"}"""
     val parsedJson = decode[NewsletterCutOff](json).right.get
-    Await.result(GetCleanseListLambda.process(List(parsedJson)), GetCleanseListLambda.timeout)
+    val getCleanseListLambda = new GetCleanseListLambda
+    Await.result(getCleanseListLambda.process(List(parsedJson)), getCleanseListLambda.timeout)
   }
 }

--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCutOffDatesLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCutOffDatesLambda.scala
@@ -1,15 +1,15 @@
 package com.gu.newsletterlistcleanse
 
-import java.io.InputStream
 import java.util.concurrent.TimeUnit
 
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.amazonaws.services.sqs.model.SendMessageResult
 import com.gu.newsletterlistcleanse.db.{BigQueryOperations, DatabaseOperations}
 import com.gu.newsletterlistcleanse.models.NewsletterCutOff
 import com.gu.newsletterlistcleanse.sqs.AwsSQSSend
-import com.gu.newsletterlistcleanse.sqs.AwsSQSSend.{Payload, QueueName}
+import com.gu.newsletterlistcleanse.sqs.AwsSQSSend.Payload
 import org.slf4j.{Logger, LoggerFactory}
 import io.circe.syntax._
 
@@ -27,9 +27,9 @@ class GetCutOffDatesLambda {
 
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
   val credentialProvider: AWSCredentialsProvider = new NewsletterSQSAWSCredentialProvider()
-  val sqsClient = AwsSQSSend.buildSqsClient(credentialProvider)
+  val sqsClient: AmazonSQSAsync = AwsSQSSend.buildSqsClient(credentialProvider)
   val config: NewsletterConfig = NewsletterConfig.load(credentialProvider)
-  val databaseOperations: DatabaseOperations = new BigQueryOperations(config.serviceAccount)
+  val databaseOperations: DatabaseOperations = new BigQueryOperations(config.serviceAccount, config.projectId)
   val newsletters: Newsletters = new Newsletters()
 
   val timeout: Duration = Duration(15, TimeUnit.MINUTES)

--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCutOffDatesLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCutOffDatesLambda.scala
@@ -16,7 +16,6 @@ import scala.beans.BeanProperty
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.io.Source
 
 case class GetCutOffDatesLambdaInput(
   @BeanProperty
@@ -26,8 +25,8 @@ case class GetCutOffDatesLambdaInput(
 class GetCutOffDatesLambda {
 
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
-  val serviceAccountCredentials: InputStream = this.getClass.getClassLoader().getResource("service-account.json").openStream()
-  val databaseOperations: DatabaseOperations = new BigQueryOperations(serviceAccountCredentials)
+  val config: NewsletterConfig = NewsletterConfig.load()
+  val databaseOperations: DatabaseOperations = new BigQueryOperations(config.serviceAccount)
   val newsletters: Newsletters = new Newsletters()
 
   val timeout: Duration = Duration(15, TimeUnit.MINUTES)

--- a/src/main/scala/com/gu/newsletterlistcleanse/NewsletterConfig.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/NewsletterConfig.scala
@@ -16,7 +16,7 @@ object NewsletterConfig {
   def load(credentialProvider: AWSCredentialsProvider): NewsletterConfig = {
     val identity = AppIdentity.whoAmI(defaultAppName = "newsletter-list-cleanse", credentialProvider)
     val config = ConfigurationLoader.load(identity, credentialProvider) {
-      case identity: AwsIdentity => SSMConfigurationLocation.default(identity)
+      case identity: AwsIdentity => SSMConfigurationLocation(s"/${identity.stack}/${identity.app}/${identity.stage}")
     }
     NewsletterConfig(
       serviceAccount = config.getString("serviceAccount"),

--- a/src/main/scala/com/gu/newsletterlistcleanse/NewsletterConfig.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/NewsletterConfig.scala
@@ -1,0 +1,22 @@
+package com.gu.newsletterlistcleanse
+
+import com.gu.{AppIdentity, AwsIdentity}
+import com.gu.conf.{ConfigurationLoader, SSMConfigurationLocation}
+
+case class NewsletterConfig(
+  serviceAccount: String,
+  brazeApiToken: String
+)
+
+object NewsletterConfig {
+  def load(): NewsletterConfig = {
+    val identity = AppIdentity.whoAmI(defaultAppName = "newsletter-list-cleanse")
+    val config = ConfigurationLoader.load(identity) {
+      case identity: AwsIdentity => SSMConfigurationLocation.default(identity)
+    }
+    NewsletterConfig(
+      serviceAccount = config.getString("serviceAccount"),
+      brazeApiToken = config.getString("brazeApiToken")
+    )
+  }
+}

--- a/src/main/scala/com/gu/newsletterlistcleanse/NewsletterConfig.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/NewsletterConfig.scala
@@ -6,6 +6,7 @@ import com.gu.conf.{ConfigurationLoader, SSMConfigurationLocation}
 
 case class NewsletterConfig(
   serviceAccount: String,
+  projectId: String,
   brazeApiToken: String,
   cutOffSqsUrl: String,
   cleanseListSqsUrl: String
@@ -19,6 +20,7 @@ object NewsletterConfig {
     }
     NewsletterConfig(
       serviceAccount = config.getString("serviceAccount"),
+      projectId = config.getString("projectId"),
       brazeApiToken = config.getString("brazeApiToken"),
       cutOffSqsUrl = config.getString("cutOffSqsUrl"),
       cleanseListSqsUrl = config.getString("cleanseListSqsUrl")

--- a/src/main/scala/com/gu/newsletterlistcleanse/NewsletterConfig.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/NewsletterConfig.scala
@@ -1,22 +1,27 @@
 package com.gu.newsletterlistcleanse
 
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.gu.{AppIdentity, AwsIdentity}
 import com.gu.conf.{ConfigurationLoader, SSMConfigurationLocation}
 
 case class NewsletterConfig(
   serviceAccount: String,
-  brazeApiToken: String
+  brazeApiToken: String,
+  cutOffSqsUrl: String,
+  cleanseListSqsUrl: String
 )
 
 object NewsletterConfig {
-  def load(): NewsletterConfig = {
-    val identity = AppIdentity.whoAmI(defaultAppName = "newsletter-list-cleanse")
-    val config = ConfigurationLoader.load(identity) {
+  def load(credentialProvider: AWSCredentialsProvider): NewsletterConfig = {
+    val identity = AppIdentity.whoAmI(defaultAppName = "newsletter-list-cleanse", credentialProvider)
+    val config = ConfigurationLoader.load(identity, credentialProvider) {
       case identity: AwsIdentity => SSMConfigurationLocation.default(identity)
     }
     NewsletterConfig(
       serviceAccount = config.getString("serviceAccount"),
-      brazeApiToken = config.getString("brazeApiToken")
+      brazeApiToken = config.getString("brazeApiToken"),
+      cutOffSqsUrl = config.getString("cutOffSqsUrl"),
+      cleanseListSqsUrl = config.getString("cleanseListSqsUrl")
     )
   }
 }

--- a/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
@@ -3,6 +3,7 @@ package com.gu.newsletterlistcleanse
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
 import com.gu.newsletterlistcleanse.EitherConverter.EitherList
 import com.gu.newsletterlistcleanse.Newsletters.getIdentityNewsletterFromName
@@ -12,7 +13,6 @@ import io.circe
 import io.circe.parser.decode
 import org.slf4j.{Logger, LoggerFactory}
 
-
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.Duration
 
@@ -21,7 +21,8 @@ class UpdateBrazeUsersLambda {
 
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
-  val config: NewsletterConfig = NewsletterConfig.load()
+  val credentialProvider: AWSCredentialsProvider = new NewsletterSQSAWSCredentialProvider()
+  val config: NewsletterConfig = NewsletterConfig.load(credentialProvider)
 
   val timeout: Duration = Duration(15, TimeUnit.MINUTES)
 

--- a/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
@@ -23,6 +23,8 @@ object UpdateBrazeUsersLambda {
 
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
+  val config: NewsletterConfig = NewsletterConfig.load()
+
   val timeout: Duration = Duration(15, TimeUnit.MINUTES)
 
   def handler(sqsEvent: SQSEvent): Unit = {
@@ -55,7 +57,7 @@ object UpdateBrazeUsersLambda {
       identityNewsletter <- getIdentityNewsletterFromName(newsletterName)
     } yield {
 
-      val apiKey: String = Option(System.getenv("BRAZE_API_KEY")).getOrElse("")
+      val apiKey: String = config.brazeApiToken
       val timestamp: Instant = Instant.now()
       val subscriptionsUpdate = BrazeNewsletterSubscriptionsUpdate(userId, Map((identityNewsletter, false)))
 

--- a/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
@@ -1,7 +1,6 @@
 package com.gu.newsletterlistcleanse
 
-import java.time.format.DateTimeFormatter
-import java.time.{Instant, ZoneId, ZonedDateTime}
+import java.time.Instant
 import java.util.concurrent.TimeUnit
 
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
@@ -15,11 +14,10 @@ import org.slf4j.{Logger, LoggerFactory}
 
 
 import scala.collection.JavaConverters._
-import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
 
-object UpdateBrazeUsersLambda {
+class UpdateBrazeUsersLambda {
 
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
@@ -73,7 +71,8 @@ object UpdateBrazeUsersLambda {
 
 object TestUpdateBrazeUsers {
   def main(args: Array[String]): Unit = {
-    val cleanseLists= List(CleanseList("Editorial_AnimalsFarmed", List("user_1_jrb", "user_2_jrb")))
-    println(UpdateBrazeUsersLambda.process(cleanseLists))
+    val cleanseLists = List(CleanseList("Editorial_AnimalsFarmed", List("user_1_jrb", "user_2_jrb")))
+    val updateBrazeUsersLambda = new UpdateBrazeUsersLambda()
+    println(updateBrazeUsersLambda.process(cleanseLists))
   }
 }

--- a/src/main/scala/com/gu/newsletterlistcleanse/db/BigQueryOperations.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/db/BigQueryOperations.scala
@@ -11,7 +11,7 @@ import com.google.auth.oauth2.ServiceAccountCredentials
 
 import scala.collection.JavaConverters._
 
-class BigQueryOperations(serviceAccount: String) extends DatabaseOperations {
+class BigQueryOperations(serviceAccount: String, projectId: String) extends DatabaseOperations {
 
   private val serviceAccountInputStream = new ByteArrayInputStream(serviceAccount.getBytes(StandardCharsets.UTF_8))
 
@@ -24,7 +24,7 @@ class BigQueryOperations(serviceAccount: String) extends DatabaseOperations {
   private val bigQuery: BigQuery = BigQueryOptions
     .newBuilder()
     .setCredentials(credentials)
-    .setProjectId("datatech-platform-code")
+    .setProjectId(projectId)
     .build()
     .getService
 

--- a/src/main/scala/com/gu/newsletterlistcleanse/db/BigQueryOperations.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/db/BigQueryOperations.scala
@@ -1,6 +1,7 @@
 package com.gu.newsletterlistcleanse.db
 
-import java.io.InputStream
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
 import java.time.{Instant, ZoneId, ZonedDateTime}
 
 import com.gu.newsletterlistcleanse.models.NewsletterCutOff
@@ -10,15 +11,17 @@ import com.google.auth.oauth2.ServiceAccountCredentials
 
 import scala.collection.JavaConverters._
 
-class BigQueryOperations(googleCredentials: InputStream) extends DatabaseOperations {
+class BigQueryOperations(serviceAccount: String) extends DatabaseOperations {
 
-  val credentials: Credentials = ServiceAccountCredentials
-    .fromStream(googleCredentials)
+  private val serviceAccountInputStream = new ByteArrayInputStream(serviceAccount.getBytes(StandardCharsets.UTF_8))
+
+  private val credentials: Credentials = ServiceAccountCredentials
+    .fromStream(serviceAccountInputStream)
     .toBuilder
     .setScopes(List("https://www.googleapis.com/auth/bigquery").asJavaCollection)
     .build()
 
-  val bigQuery: BigQuery = BigQueryOptions
+  private val bigQuery: BigQuery = BigQueryOptions
     .newBuilder()
     .setCredentials(credentials)
     .setProjectId("datatech-platform-code")

--- a/src/main/scala/com/gu/newsletterlistcleanse/sqs/AwsSQSSend.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/sqs/AwsSQSSend.scala
@@ -9,7 +9,6 @@ import org.slf4j.{Logger, LoggerFactory}
 import scala.concurrent.Future
 
 object AwsSQSSend {
-  case class QueueName(value: String) extends AnyVal
 
   case class Payload(value: String) extends AnyVal
 

--- a/src/main/scala/com/gu/newsletterlistcleanse/sqs/AwsSQSSend.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/sqs/AwsSQSSend.scala
@@ -1,9 +1,9 @@
 package com.gu.newsletterlistcleanse.sqs
 
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.sqs.model.{SendMessageRequest, SendMessageResult}
 import com.amazonaws.services.sqs.{AmazonSQSAsync, AmazonSQSAsyncClientBuilder}
-import com.gu.newsletterlistcleanse.NewsletterSQSAWSCredentialProvider
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.concurrent.Future
@@ -15,21 +15,15 @@ object AwsSQSSend {
 
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
-  private def buildSqsClient(queueName: QueueName): (AmazonSQSAsync, String) = {
-
-    val sqsClient = AmazonSQSAsyncClientBuilder
+  def buildSqsClient(credentialProvider: AWSCredentialsProvider): AmazonSQSAsync = {
+    AmazonSQSAsyncClientBuilder
       .standard()
-      .withCredentials(new NewsletterSQSAWSCredentialProvider())
+      .withCredentials(credentialProvider)
       .withRegion(Regions.EU_WEST_1)
       .build()
-
-    val queueUrl = sqsClient.getQueueUrl(queueName.value).getQueueUrl
-    (sqsClient, queueUrl)
   }
 
-  def sendMessage(queueName: QueueName, payload: Payload): Future[SendMessageResult] = {
-    val (sqsClient: AmazonSQSAsync, queueUrl: String) = buildSqsClient(queueName)
-
+  def sendMessage(sqsClient: AmazonSQSAsync, queueUrl: String, payload: Payload): Future[SendMessageResult] = {
     val request: SendMessageRequest = new SendMessageRequest(queueUrl, payload.value)
 
     AwsAsync(sqsClient.sendMessageAsync, request)


### PR DESCRIPTION
## What does this change?
 - load the configuration from SSM, using the simple-configuration library
 - refactor the AWS clients such that they use the same credentials
 - slight change of behaviour in our SQS logic, such that we create one client for the whole lifetime of the lambda

## How to test
Will be testable on CODE

## How can we measure success?
N/A

## Have we considered potential risks?
N/A

## Todo
 - [x] Add the configuration in SSM CODE
 - [x] Test in CODE
 - [x] Add the configuration in SSM PROD

_Note: We're currently awaiting for the production credentials_
