### PR TITLE
Query for getting active user list length

### DIFF
--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
@@ -11,7 +11,7 @@ import com.gu.newsletterlistcleanse.models.{CleanseList, NewsletterCutOff}
 import com.gu.newsletterlistcleanse.sqs.AwsSQSSend
 import com.gu.newsletterlistcleanse.sqs.AwsSQSSend.Payload
 import com.gu.newsletterlistcleanse.EitherConverter.EitherList
-import com.gu.newsletterlistcleanse.db.ActiveListLength.getActiveListLength
+
 import io.circe
 import io.circe.parser._
 import io.circe.syntax._
@@ -59,7 +59,6 @@ class GetCleanseListLambda {
   def process(campaignCutOffDates: List[NewsletterCutOff]): Future[List[SendMessageResult]]  = {
     val env = Env()
     logger.info(s"Starting $env")
-    val listLengths = databaseOperations.fetchCampaignActiveListLength(campaignCutOffDates)
 
     val results = for {
       campaignCutOff <- campaignCutOffDates
@@ -69,8 +68,7 @@ class GetCleanseListLambda {
         userIds
       )
 
-      activeCount = getActiveListLength(listLengths, campaignCutOff.newsletterName)
-      _ = logger.info(s"Found ${userIds.length} users of $activeCount to remove from ${campaignCutOff.newsletterName}")
+      _ = logger.info(s"Found ${userIds.length} users of ${campaignCutOff.activeListLength} to remove from ${campaignCutOff.newsletterName}")
 
       batchedCleanseList = cleanseList.getCleanseListBatches(5000)
       (batch, index) <- batchedCleanseList.zipWithIndex

--- a/src/main/scala/com/gu/newsletterlistcleanse/db/ActiveListLength.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/db/ActiveListLength.scala
@@ -1,0 +1,16 @@
+package com.gu.newsletterlistcleanse.db
+
+import scalikejdbc.WrappedResultSet
+
+case class ActiveListLength(newsletterName: String, listLength: Int)
+
+object ActiveListLength {
+  def fromRow(rs: WrappedResultSet): ActiveListLength =
+    ActiveListLength(
+      newsletterName = rs.string("newsletter_name"),
+      listLength = rs.int("list_length")
+    )
+
+  def getActiveListLength(listLengths: List[ActiveListLength], newsletterName: String): Int =
+    listLengths.find(listLength => listLength.newsletterName == newsletterName).map(_.listLength).getOrElse(0)
+}

--- a/src/main/scala/com/gu/newsletterlistcleanse/db/AthenaOperations.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/db/AthenaOperations.scala
@@ -61,14 +61,13 @@ class AthenaOperations extends DatabaseOperations {
     }
   }
 
-  override def fetchCampaignActiveListLength(newsletterCutOffs: List[NewsletterCutOff]): List[ActiveListLength] = {
-    val campaignNames = newsletterCutOffs.map(_.newsletterName)
+  override def fetchCampaignActiveListLength(newsletterNames: List[String]): List[ActiveListLength] = {
     DB.athena { implicit session =>
       sql"""SELECT newsletter_name,
            |         count(identity_id) AS list_length
            |FROM "clean"."braze_newsletter_membership"
            |WHERE customer_status='active'
-           |        AND newsletter_name IN ($campaignNames)
+           |        AND newsletter_name IN ($newsletterNames)
            |GROUP BY  newsletter_name;""".stripMargin.map(ActiveListLength.fromRow).list.apply()
     }
   }

--- a/src/main/scala/com/gu/newsletterlistcleanse/db/AthenaOperations.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/db/AthenaOperations.scala
@@ -60,4 +60,17 @@ class AthenaOperations extends DatabaseOperations {
         """.map(UserID.fromRow).list().apply()
     }
   }
+
+  override def fetchCampaignActiveListLength(newsletterCutOffs: List[NewsletterCutOff]): List[ActiveListLength] = {
+    val campaignNames = newsletterCutOffs.map(_.newsletterName)
+    DB.athena { implicit session =>
+      sql"""SELECT newsletter_name,
+           |         count(identity_id) AS list_length
+           |FROM "clean"."braze_newsletter_membership"
+           |WHERE customer_status='active'
+           |        AND newsletter_name IN ($campaignNames)
+           |GROUP BY  newsletter_name;""".stripMargin.map(ActiveListLength.fromRow).list.apply()
+    }
+  }
+
 }

--- a/src/main/scala/com/gu/newsletterlistcleanse/db/BigQueryOperations.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/db/BigQueryOperations.scala
@@ -106,4 +106,27 @@ class BigQueryOperations(serviceAccount: String, projectId: String) extends Data
       UserID(result.get("user_id").getStringValue)
     }
   }
+
+  override def fetchCampaignActiveListLength(newsletterCutOffs: List[NewsletterCutOff]): List[ActiveListLength] = {
+    val campaignNames = newsletterCutOffs.map(_.newsletterName)
+    val sql = """SELECT newsletter_name,
+                 |         count(identity_id) AS listLength
+                 |FROM `datalake.braze_newsletter_membership`
+                 |WHERE customer_status='active'
+                 |        AND newsletter_name IN UNNEST(@campaignNames)
+                 |GROUP BY newsletter_name;""".stripMargin
+
+    val queryConfig = QueryJobConfiguration.newBuilder(sql)
+      .addNamedParameter("campaignNames", QueryParameterValue.array(campaignNames.toArray, classOf[String]))
+      .setUseLegacySql(false)
+      .build()
+    val results = bigQuery.query(queryConfig)
+
+    results.iterateAll().asScala.toList.map { result =>
+      ActiveListLength(
+        newsletterName = result.get("newsletter_name").getStringValue,
+        listLength = result.get("listLength").getLongValue.toInt
+      )
+    }
+  }
 }

--- a/src/main/scala/com/gu/newsletterlistcleanse/db/BigQueryOperations.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/db/BigQueryOperations.scala
@@ -107,17 +107,16 @@ class BigQueryOperations(serviceAccount: String, projectId: String) extends Data
     }
   }
 
-  override def fetchCampaignActiveListLength(newsletterCutOffs: List[NewsletterCutOff]): List[ActiveListLength] = {
-    val campaignNames = newsletterCutOffs.map(_.newsletterName)
+  override def fetchCampaignActiveListLength(newsletterNames: List[String]): List[ActiveListLength] = {
     val sql = """SELECT newsletter_name,
                  |         count(identity_id) AS listLength
                  |FROM `datalake.braze_newsletter_membership`
                  |WHERE customer_status='active'
-                 |        AND newsletter_name IN UNNEST(@campaignNames)
+                 |        AND newsletter_name IN UNNEST(@newsletterNames)
                  |GROUP BY newsletter_name;""".stripMargin
 
     val queryConfig = QueryJobConfiguration.newBuilder(sql)
-      .addNamedParameter("campaignNames", QueryParameterValue.array(campaignNames.toArray, classOf[String]))
+      .addNamedParameter("newsletterNames", QueryParameterValue.array(newsletterNames.toArray, classOf[String]))
       .setUseLegacySql(false)
       .build()
     val results = bigQuery.query(queryConfig)

--- a/src/main/scala/com/gu/newsletterlistcleanse/db/DatabaseOperations.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/db/DatabaseOperations.scala
@@ -7,7 +7,7 @@ trait DatabaseOperations {
 
   def fetchCampaignCleanseList(newsletterCutOff: NewsletterCutOff): List[UserID]
 
-  def fetchCampaignActiveListLength(newsletterCutOffs: List[NewsletterCutOff]): List[ActiveListLength]
+  def fetchCampaignActiveListLength(newsletterNames: List[String]): List[ActiveListLength]
 }
 
 

--- a/src/main/scala/com/gu/newsletterlistcleanse/db/DatabaseOperations.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/db/DatabaseOperations.scala
@@ -6,6 +6,8 @@ trait DatabaseOperations {
   def fetchCampaignSentDates(campaignNames: List[String], cutOffLength: Int): List[CampaignSentDate]
 
   def fetchCampaignCleanseList(newsletterCutOff: NewsletterCutOff): List[UserID]
+
+  def fetchCampaignActiveListLength(newsletterCutOffs: List[NewsletterCutOff]): List[ActiveListLength]
 }
 
 

--- a/src/main/scala/com/gu/newsletterlistcleanse/models/NewsletterCutOff.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/models/NewsletterCutOff.scala
@@ -7,7 +7,8 @@ import io.circe.generic.semiauto.{deriveEncoder, deriveDecoder}
 
 case class NewsletterCutOff(
   newsletterName: String,
-  cutOffDate: ZonedDateTime
+  cutOffDate: ZonedDateTime,
+  activeListLength: Int
 )
 
 object NewsletterCutOff {


### PR DESCRIPTION
## What does this change?
To properly assess the impact of the list cleanse and to make sure that we can implement a circuit breaker to kick in if the cleanse fraction looks too high, we need to be able to query for the number of current active users.

This adds that query in here and implements it in the `getCleanseList` lambda.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Run locally with command from README

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
N/A

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
No additional permissions past what is already present.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
N/A