### PR TITLE
Add check for existing Braze users

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,8 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-core" % "0.12.3",
   "io.circe" %% "circe-generic" % "0.12.3",
   "io.circe" %% "circe-parser"% "0.12.3",
-  "org.scalaj" %% "scalaj-http" % "2.4.2"
+  "com.softwaremill.sttp.client" %% "core" % "2.2.7",
+  "com.softwaremill.sttp.client" %% "async-http-client-backend-future" % "2.2.7"
 )
 assemblyJarName := s"${name.value}.jar"
 assemblyMergeStrategy in assembly := {

--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
@@ -8,7 +8,7 @@ import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.amazonaws.services.sqs.model.SendMessageResult
 import com.gu.newsletterlistcleanse.db.{BigQueryOperations, DatabaseOperations}
 import com.gu.newsletterlistcleanse.models.{CleanseList, NewsletterCutOff}
-import com.gu.newsletterlistcleanse.sqs.{AwsSQSSend, ParseSqsMessage}
+import com.gu.newsletterlistcleanse.sqs.{AwsSQSSend, SqsMessageParser}
 import com.gu.newsletterlistcleanse.sqs.AwsSQSSend.Payload
 import io.circe.parser._
 import io.circe.syntax._
@@ -31,7 +31,7 @@ class GetCleanseListLambda {
   val timeout: Duration = Duration(15, TimeUnit.MINUTES)
 
   def handler(sqsEvent: SQSEvent): Unit = {
-    ParseSqsMessage[NewsletterCutOff](sqsEvent) match {
+    SqsMessageParser.parse[NewsletterCutOff](sqsEvent) match {
       case Right(newsletterCutOffs) =>
         Await.result(process(newsletterCutOffs), timeout)
       case Left(parseErrors) =>

--- a/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
@@ -24,8 +24,8 @@ class UpdateBrazeUsersLambda {
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
   val credentialProvider: AWSCredentialsProvider = new NewsletterSQSAWSCredentialProvider()
-  val apiKey: String = config.brazeApiToken
   val config: NewsletterConfig = NewsletterConfig.load(credentialProvider)
+  val apiKey: String = config.brazeApiToken
 
   val timeout: Duration = Duration(15, TimeUnit.MINUTES)
 
@@ -74,11 +74,10 @@ class UpdateBrazeUsersLambda {
     val requests = for {
       userId <- userIds
     } yield {
-      val subscriptionsUpdate = BrazeNewsletterSubscriptionsUpdate(userId, Map((identityNewsletter, false)))
-
-      UserTrackRequest(subscriptionsUpdate, timestamp)
+      BrazeNewsletterSubscriptionsUpdate(userId, Map((identityNewsletter, false)))
     }
-    BrazeClient.updateUser(apiKey, requests)
+
+    BrazeClient.updateUser(apiKey, UserTrackRequest(requests, timestamp))
   }
 
   private def sendBrazeUpdates(cleanseLists: List[CleanseList], allInvalidUsers: Set[String]): Future[Either[List[BrazeError], List[SimpleBrazeResponse]]] = {
@@ -110,7 +109,7 @@ class UpdateBrazeUsersLambda {
 
 object TestUpdateBrazeUsers {
   def main(args: Array[String]): Unit = {
-    val cleanseLists = List(CleanseList("Editorial_AnimalsFarmed", List("user_1_jrb", "user_2_jrb")))
+    val cleanseLists = List(CleanseList("Editorial_AnimalsFarmed", List("user_1_jrb", "user_2_jrb", "mystery_user 1")))
     val updateBrazeUsersLambda = new UpdateBrazeUsersLambda()
     println(updateBrazeUsersLambda.process(cleanseLists))
   }

--- a/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
@@ -55,7 +55,7 @@ class UpdateBrazeUsersLambda {
   }
 
   def getInvalidUsers(userIds: List[String]): Future[Either[BrazeError, List[String]]] = {
-    val request: UserExportRequest = UserExportRequest.apply(userIds)
+    val request: UserExportRequest = UserExportRequest(userIds)
     BrazeClient.getInvalidUsers(apiKey, request)
   }
 
@@ -76,7 +76,7 @@ class UpdateBrazeUsersLambda {
     } yield {
       val subscriptionsUpdate = BrazeNewsletterSubscriptionsUpdate(userId, Map((identityNewsletter, false)))
 
-      UserTrackRequest.apply(subscriptionsUpdate, timestamp)
+      UserTrackRequest(subscriptionsUpdate, timestamp)
     }
     BrazeClient.updateUser(apiKey, requests)
   }

--- a/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeClient.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeClient.scala
@@ -30,11 +30,11 @@ object BrazeClient {
       result <- results
       } {
         result.foreach { successResult =>
-          logger.info(s"BrazeClient success $info $successResult")
+          logger.info(s"BrazeClient success: $info $successResult")
         }
 
         result.left.foreach { errorResult =>
-          logger.error(s"BrazeClient failure $info $errorResult")
+          logger.error(s"BrazeClient failure: $info $errorResult")
         }
       }
 
@@ -62,7 +62,7 @@ object BrazeClient {
     })
   }
 
-  def updateUser(apiKey: String, requests: List[UserTrackRequest]): Future[Either[BrazeError, SimpleBrazeResponse]] = {
+  def updateUser(apiKey: String, requests: UserTrackRequest): Future[Either[BrazeError, SimpleBrazeResponse]] = {
     val jsonRequest = requests.asJson.toString
     // TODO: Make logging more useful whilst maintaining data security
     withClientLogging(s"updating user subscriptions"){
@@ -80,7 +80,7 @@ object BrazeClient {
 
   def getInvalidUsers(apiKey: String, request: UserExportRequest): Future[Either[BrazeError, List[String]]] = {
     val jsonRequest = request.asJson.toString
-    withClientLogging(s"Checking for invalid user IDs") {
+    withClientLogging(s"getting invalid user IDs") {
       val response = basicRequest
         .post(uri"$brazeEndpoint/users/export/ids")
         .readTimeout(timeout)

--- a/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeClient.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeClient.scala
@@ -8,6 +8,9 @@ import sttp.client.asynchttpclient.future.AsyncHttpClientFutureBackend
 import scala.concurrent.duration._
 import io.circe.parser.decode
 import io.circe.syntax._
+import org.asynchttpclient.{AsyncHttpClient, DefaultAsyncHttpClientConfig}
+import org.asynchttpclient.Dsl.{asyncHttpClient, config}
+import sttp.client.asynchttpclient.WebSocketHandler
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -16,9 +19,12 @@ import scala.concurrent.ExecutionContext.Implicits.global
 object BrazeClient {
 
   private val timeout = 5000.seconds
-  implicit val sttpBackend = AsyncHttpClientFutureBackend(
-    options=SttpBackendOptions.connectionTimeout(timeout)
-  )
+
+  private val sttpOptions = SttpBackendOptions.connectionTimeout(timeout)
+  private val adjustFunction: DefaultAsyncHttpClientConfig.Builder => DefaultAsyncHttpClientConfig.Builder =
+    (defaultConfig) => defaultConfig.setMaxConnections(3)
+  implicit val sttpBackend: SttpBackend[Future, Nothing, WebSocketHandler] = AsyncHttpClientFutureBackend
+    .usingConfigBuilder(adjustFunction, sttpOptions)
 
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
   val brazeEndpoint = "https://rest.fra-01.braze.eu"

--- a/src/main/scala/com/gu/newsletterlistcleanse/sqs/ParseSqsMessage.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/sqs/ParseSqsMessage.scala
@@ -1,0 +1,21 @@
+package com.gu.newsletterlistcleanse.sqs
+
+import com.amazonaws.services.lambda.runtime.events.SQSEvent
+import io.circe
+import io.circe.Decoder
+import io.circe.parser.decode
+import scala.collection.JavaConverters._
+import com.gu.newsletterlistcleanse.EitherConverter.EitherList
+
+
+
+object ParseSqsMessage {
+
+  def apply[T: Decoder](sqsEvent: SQSEvent): Either[List[circe.Error], List[T]] = {
+    (for {
+      message <- sqsEvent.getRecords.asScala.toList
+    } yield {
+      decode[T](message.getBody)
+    }).toEitherList
+  }
+}

--- a/src/main/scala/com/gu/newsletterlistcleanse/sqs/SqsMessageParser.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/sqs/SqsMessageParser.scala
@@ -9,9 +9,8 @@ import com.gu.newsletterlistcleanse.EitherConverter.EitherList
 
 
 
-object ParseSqsMessage {
-
-  def apply[T: Decoder](sqsEvent: SQSEvent): Either[List[circe.Error], List[T]] = {
+object SqsMessageParser {
+  def parse[T: Decoder](sqsEvent: SQSEvent): Either[List[circe.Error], List[T]] = {
     (for {
       message <- sqsEvent.getRecords.asScala.toList
     } yield {


### PR DESCRIPTION
## What does this change?
Because the `/track` endpoint will create a new user if an unknown external ID is passed in, we need to check for any invalid IDs before sending our subscription updates. We can do this using the export users by ID endpoint.

### Changes:
 - Move to asynchronous http client
 - Add Braze export users by ID endpoint and code
 - Handle Braze updates in batches


