### PR TITLE
Support guardian today uk

### DIFF
--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
@@ -56,13 +56,21 @@ class GetCleanseListLambda {
     AwsSQSSend.sendMessage(sqsClient, config.cleanseListSqsUrl, Payload(cleanseList.asJson.noSpaces))
   }
 
+  def fetchCampaignCleanseList(campaignCutOff: NewsletterCutOff): List[String] = {
+    if (campaignCutOff.newsletterName == Newsletters.guardianTodayUK) {
+      databaseOperations.fetchGuardianTodayUKCleanseList(campaignCutOff).map(_.userId)
+    } else {
+      databaseOperations.fetchCampaignCleanseList(campaignCutOff).map(_.userId)
+    }
+  }
+
   def process(campaignCutOffDates: List[NewsletterCutOff]): Future[List[SendMessageResult]]  = {
     val env = Env()
     logger.info(s"Starting $env")
 
     val results = for {
       campaignCutOff <- campaignCutOffDates
-      userIds = databaseOperations.fetchCampaignCleanseList(campaignCutOff).map(_.userId)
+      userIds = fetchCampaignCleanseList(campaignCutOff)
       cleanseList = CleanseList(
         campaignCutOff.newsletterName,
         userIds
@@ -83,7 +91,7 @@ class GetCleanseListLambda {
 
 object TestGetCleanseList {
   def main(args: Array[String]): Unit = {
-    val json = """{"newsletterName":"Editorial_AnimalsFarmed","cutOffDate":"2020-01-21T11:31:14Z[Europe/London]"}"""
+    val json = """{"newsletterName":"Editorial_GuardianTodayUK","cutOffDate":"2020-06-07T11:31:14Z[Europe/London]", "activeListLength": 1000}"""
     val parsedJson = decode[NewsletterCutOff](json).right.get
     val getCleanseListLambda = new GetCleanseListLambda
     Await.result(getCleanseListLambda.process(List(parsedJson)), getCleanseListLambda.timeout)

--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCutOffDatesLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCutOffDatesLambda.scala
@@ -62,15 +62,14 @@ class GetCutOffDatesLambda {
     } else Nil
     val cutOffDates = newsletters.computeCutOffDates(campaignSentDates ++ guardianTodayUKSentDates, listLengths)
     logger.info(s"result: ${cutOffDates.asJson.noSpaces}")
-    //sendCutOffs(cutOffDates)
-    Future.successful(Nil)
+    sendCutOffs(cutOffDates)
   }
 }
 
 object TestGetCutOffDates {
   def main(args: Array[String]): Unit = {
     val getCutOffDatesLambda = new GetCutOffDatesLambda()
-    val lambdaInput = GetCutOffDatesLambdaInput(None)
+    val lambdaInput = GetCutOffDatesLambdaInput(Some(List("Editorial_AnimalsFarmed", "Editorial_TheLongRead")))
     Await.result(getCutOffDatesLambda.process(lambdaInput), getCutOffDatesLambda.timeout)
   }
 }

--- a/src/main/scala/com/gu/newsletterlistcleanse/Newsletters.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/Newsletters.scala
@@ -92,6 +92,9 @@ object Newsletters {
 
   val maxCutOffPeriod = cleansingPolicy.valuesIterator.max
 
+  val guardianTodayUK = "Editorial_GuardianTodayUK"
+  val guardianTodayUKCampaigns = List("Editorial_GuardianTodayUK_Weekend", "Editorial_GuardianTodayUK_Weekdays")
+
   val attributeToNewsletterMapping: Map[String, String] = Map(
     "TodayUk_Subscribe_Email" -> "Editorial_GuardianTodayUK",
     "TodayUs_Subscribe_Email" -> "Editorial_GuardianTodayUS",

--- a/src/main/scala/com/gu/newsletterlistcleanse/Newsletters.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/Newsletters.scala
@@ -26,7 +26,7 @@ class Newsletters {
       activeCount = getActiveListLength(listLengths, campaignName)
       cutOff <- sentDates
         .sortBy(_.timestamp)(reverseChrono)
-        .drop(unOpenCount)
+        .drop(unOpenCount - 1)
         .headOption
         .map(send => NewsletterCutOff(campaignName, send.timestamp, activeCount))
     } yield cutOff

--- a/src/main/scala/com/gu/newsletterlistcleanse/db/AthenaOperations.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/db/AthenaOperations.scala
@@ -28,6 +28,8 @@ class AthenaOperations extends DatabaseOperations {
     }
   }
 
+  override def fetchGuardianTodayUKSentDates(cutOffLength: Int): List[CampaignSentDate] = ???
+
   override def fetchCampaignCleanseList(newsletterCutOff: NewsletterCutOff): List[UserID] = {
     val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
     val formattedDate = newsletterCutOff.cutOffDate.format(formatter)

--- a/src/main/scala/com/gu/newsletterlistcleanse/db/AthenaOperations.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/db/AthenaOperations.scala
@@ -63,6 +63,8 @@ class AthenaOperations extends DatabaseOperations {
     }
   }
 
+  override def fetchGuardianTodayUKCleanseList(newsletterCutOff: NewsletterCutOff): List[UserID] = ???
+
   override def fetchCampaignActiveListLength(newsletterNames: List[String]): List[ActiveListLength] = {
     DB.athena { implicit session =>
       sql"""SELECT newsletter_name,

--- a/src/main/scala/com/gu/newsletterlistcleanse/db/DatabaseOperations.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/db/DatabaseOperations.scala
@@ -9,6 +9,8 @@ trait DatabaseOperations {
 
   def fetchCampaignCleanseList(newsletterCutOff: NewsletterCutOff): List[UserID]
 
+  def fetchGuardianTodayUKCleanseList(newsletterCutOff: NewsletterCutOff): List[UserID]
+
   def fetchCampaignActiveListLength(newsletterNames: List[String]): List[ActiveListLength]
 }
 

--- a/src/main/scala/com/gu/newsletterlistcleanse/db/DatabaseOperations.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/db/DatabaseOperations.scala
@@ -5,6 +5,8 @@ import com.gu.newsletterlistcleanse.models.NewsletterCutOff
 trait DatabaseOperations {
   def fetchCampaignSentDates(campaignNames: List[String], cutOffLength: Int): List[CampaignSentDate]
 
+  def fetchGuardianTodayUKSentDates(cutOffLength: Int): List[CampaignSentDate]
+
   def fetchCampaignCleanseList(newsletterCutOff: NewsletterCutOff): List[UserID]
 
   def fetchCampaignActiveListLength(newsletterNames: List[String]): List[ActiveListLength]

--- a/src/test/scala/com/gu/newsletterlistcleanse/NewslettersSpec.scala
+++ b/src/test/scala/com/gu/newsletterlistcleanse/NewslettersSpec.scala
@@ -27,16 +27,16 @@ class NewslettersSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "ignore newsletters if not enough newsletters have been sent yet to start cleansing" in {
-    val listOfSentDates = Range(0, 94).toList.map { dateOffset =>
+    val listOfSentDates = Range(0, 93).toList.map { dateOffset =>
       aCampaignSentDate.copy(timestamp = aCampaignSentDate.timestamp.plusDays(dateOffset))
     }
-    listOfSentDates.length should be(94)
+    listOfSentDates.length should be(93)
     val result = newsletters.computeCutOffDates(listOfSentDates, aListLength)
     result should be(Nil)
   }
 
   it should "pick the 94th date of the campaignSentDate" in {
-    val listOfSentDates = Range(0, 95).toList.map { dateOffset =>
+    val listOfSentDates = Range(0, 94).toList.map { dateOffset =>
       aCampaignSentDate.copy(timestamp = aCampaignSentDate.timestamp.plusDays(dateOffset))
     }
     val result = newsletters.computeCutOffDates(listOfSentDates, aListLength)
@@ -44,7 +44,7 @@ class NewslettersSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "ignore a newsletter that hasn't got a cleansing policy yet" in {
-    val listOfSentDates = Range(0, 95).toList.map { dateOffset =>
+    val listOfSentDates = Range(0, 94).toList.map { dateOffset =>
       aCampaignSentDate.copy(
         campaignName = "I_DONT_EXIST",
         timestamp = aCampaignSentDate.timestamp.plusDays(dateOffset)
@@ -59,7 +59,7 @@ class NewslettersSpec extends AnyFlatSpec with Matchers {
       aCampaignSentDate.copy(timestamp = aCampaignSentDate.timestamp.plusDays(dateOffset))
     }
     val result = newsletters.computeCutOffDates(listOfSentDates, aListLength)
-    result.head.cutOffDate should be(aDate.plusDays(999 - 94))
+    result.head.cutOffDate should be(aDate.plusDays(1000 - 94))
   }
 
   it should "pick the 94th date of the campaignSentDate, regardless of the order of the rows returned by the DB" in {
@@ -67,7 +67,7 @@ class NewslettersSpec extends AnyFlatSpec with Matchers {
       aCampaignSentDate.copy(timestamp = aCampaignSentDate.timestamp.plusDays(dateOffset))
     }
     val result = newsletters.computeCutOffDates(listOfSentDates, aListLength)
-    result.head.cutOffDate should be(aDate.plusDays(999 - 94))
+    result.head.cutOffDate should be(aDate.plusDays(1000 - 94))
   }
 
   it should "compute no matter how many campaigns are being sent" in {
@@ -81,8 +81,8 @@ class NewslettersSpec extends AnyFlatSpec with Matchers {
       )
     }
     val result = newsletters.computeCutOffDates(listOfSentDates1 ++ listOfSentDates2, aListLength)
-    result.head.cutOffDate should be(aDate.plusDays(999 - 94))
-    result(1).cutOffDate should be(aDate.plusDays(999 - 61))
+    result.head.cutOffDate should be(aDate.plusDays(1000 - 94))
+    result(1).cutOffDate should be(aDate.plusDays(1000 - 61))
   }
 
 }


### PR DESCRIPTION
 - Fix a mistake I spotted that explain why our program was being too generous in terms of cut-off date. Spoiler it was a classic 0-index mistake on my part :)
 - Refactor the BigQueryDatabaseOperations such that we repeat ourselves slightly less.
 - Add a specific cut-off date SQL query to handle the GuardianTodayUK case, leave it unimplemented in Athena
 - Add a specific cleanse-list SQL query to handle the GuardianTodayUK case, leave it unimplemented in Athena

This was tested locally