### PR TITLE
Dry run flag

### DIFF
--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
@@ -60,8 +60,9 @@ class GetCleanseListLambda {
       campaignCutOff <- campaignCutOffDates
       userIds = fetchCampaignCleanseList(campaignCutOff)
       cleanseList = CleanseList(
-        campaignCutOff.newsletterName,
-        userIds
+        newsletterName = campaignCutOff.newsletterName,
+        userIdList = userIds,
+        dryRun = campaignCutOff.dryRun
       )
 
       _ = logger.info(s"Found ${userIds.length} users of ${campaignCutOff.activeListLength} to remove from ${campaignCutOff.newsletterName}")

--- a/src/main/scala/com/gu/newsletterlistcleanse/Newsletters.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/Newsletters.scala
@@ -18,7 +18,7 @@ class Newsletters {
 
   private val reverseChrono: Ordering[ZonedDateTime] = (x: ZonedDateTime, y: ZonedDateTime) => y.compareTo(x)
 
-  def computeCutOffDates(campaignSentDates: List[CampaignSentDate], listLengths: List[ActiveListLength]): List[NewsletterCutOff] = {
+  def computeCutOffDates(campaignSentDates: List[CampaignSentDate], listLengths: List[ActiveListLength], dryRun: Boolean): List[NewsletterCutOff] = {
 
     def extractCutOffBasedOnCampaign(campaignName: String, sentDates: List[CampaignSentDate]): Option[NewsletterCutOff] = for {
 
@@ -28,7 +28,7 @@ class Newsletters {
         .sortBy(_.timestamp)(reverseChrono)
         .drop(unOpenCount - 1)
         .headOption
-        .map(send => NewsletterCutOff(campaignName, send.timestamp, activeCount))
+        .map(send => NewsletterCutOff(campaignName, send.timestamp, activeCount, dryRun))
     } yield cutOff
 
     campaignSentDates.groupBy(_.campaignName)

--- a/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
@@ -96,7 +96,7 @@ class UpdateBrazeUsersLambda {
 
 object TestUpdateBrazeUsers {
   def main(args: Array[String]): Unit = {
-    val cleanseLists = List(CleanseList("Editorial_AnimalsFarmed", List("user_1_jrb", "user_2_jrb", "mystery_user 1")))
+    val cleanseLists = List(CleanseList("Editorial_AnimalsFarmed", List("user_1_jrb", "user_2_jrb", "mystery_user 1"), dryRun = true))
     val updateBrazeUsersLambda = new UpdateBrazeUsersLambda()
     println(updateBrazeUsersLambda.getBrazeResults(cleanseLists))
   }

--- a/src/main/scala/com/gu/newsletterlistcleanse/models/CleanseList.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/models/CleanseList.scala
@@ -3,10 +3,10 @@ package com.gu.newsletterlistcleanse.models
 import io.circe.{Encoder, Decoder}
 import io.circe.generic.semiauto.{deriveEncoder, deriveDecoder}
 
-case class CleanseList(newsletterName: String, userIdList: List[String]){
+case class CleanseList(newsletterName: String, userIdList: List[String], dryRun: Boolean){
   def getCleanseListBatches(usersPerMessage: Int): List[CleanseList] = {
     this.userIdList.grouped(usersPerMessage).toList
-      .map(chunk => CleanseList(this.newsletterName, chunk ))
+      .map(chunk => CleanseList(this.newsletterName, chunk, this.dryRun))
   }
 }
 

--- a/src/main/scala/com/gu/newsletterlistcleanse/models/NewsletterCutOff.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/models/NewsletterCutOff.scala
@@ -8,7 +8,8 @@ import io.circe.generic.semiauto.{deriveEncoder, deriveDecoder}
 case class NewsletterCutOff(
   newsletterName: String,
   cutOffDate: ZonedDateTime,
-  activeListLength: Int
+  activeListLength: Int,
+  dryRun: Boolean
 )
 
 object NewsletterCutOff {

--- a/src/test/scala/com/gu/newsletterlistcleanse/NewslettersSpec.scala
+++ b/src/test/scala/com/gu/newsletterlistcleanse/NewslettersSpec.scala
@@ -3,6 +3,7 @@ package com.gu.newsletterlistcleanse
 import java.time.ZonedDateTime
 
 import com.gu.newsletterlistcleanse.db.{ActiveListLength, CampaignSentDate}
+import com.gu.newsletterlistcleanse.models.NewsletterCutOff
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -22,8 +23,16 @@ class NewslettersSpec extends AnyFlatSpec with Matchers {
     ActiveListLength("Editorial_GuardianTodayUK", 100)
   )
 
+  def computeCutOffDates(
+    campaignSentDates: List[CampaignSentDate],
+    listLengths: List[ActiveListLength] = aListLength,
+    dryRun: Boolean = true
+  ): List[NewsletterCutOff] = {
+    newsletters.computeCutOffDates(campaignSentDates, listLengths, dryRun)
+  }
+
   "The Newsletter cut-off date calculation logic" should "ignore an empty list" in {
-    newsletters.computeCutOffDates(Nil, aListLength) should be(Nil)
+    computeCutOffDates(Nil) should be(Nil)
   }
 
   it should "ignore newsletters if not enough newsletters have been sent yet to start cleansing" in {
@@ -31,7 +40,7 @@ class NewslettersSpec extends AnyFlatSpec with Matchers {
       aCampaignSentDate.copy(timestamp = aCampaignSentDate.timestamp.plusDays(dateOffset))
     }
     listOfSentDates.length should be(93)
-    val result = newsletters.computeCutOffDates(listOfSentDates, aListLength)
+    val result = computeCutOffDates(listOfSentDates)
     result should be(Nil)
   }
 
@@ -39,7 +48,7 @@ class NewslettersSpec extends AnyFlatSpec with Matchers {
     val listOfSentDates = Range(0, 94).toList.map { dateOffset =>
       aCampaignSentDate.copy(timestamp = aCampaignSentDate.timestamp.plusDays(dateOffset))
     }
-    val result = newsletters.computeCutOffDates(listOfSentDates, aListLength)
+    val result = computeCutOffDates(listOfSentDates)
     result.head.cutOffDate should be(aDate)
   }
 
@@ -50,7 +59,7 @@ class NewslettersSpec extends AnyFlatSpec with Matchers {
         timestamp = aCampaignSentDate.timestamp.plusDays(dateOffset)
       )
     }
-    val result = newsletters.computeCutOffDates(listOfSentDates, aListLength)
+    val result = computeCutOffDates(listOfSentDates)
     result should be(Nil)
   }
 
@@ -58,7 +67,7 @@ class NewslettersSpec extends AnyFlatSpec with Matchers {
     val listOfSentDates = Range(0, 1000).toList.map { dateOffset =>
       aCampaignSentDate.copy(timestamp = aCampaignSentDate.timestamp.plusDays(dateOffset))
     }
-    val result = newsletters.computeCutOffDates(listOfSentDates, aListLength)
+    val result = computeCutOffDates(listOfSentDates)
     result.head.cutOffDate should be(aDate.plusDays(1000 - 94))
   }
 
@@ -66,7 +75,7 @@ class NewslettersSpec extends AnyFlatSpec with Matchers {
     val listOfSentDates = Random.shuffle(Range(0, 1000).toList).map { dateOffset =>
       aCampaignSentDate.copy(timestamp = aCampaignSentDate.timestamp.plusDays(dateOffset))
     }
-    val result = newsletters.computeCutOffDates(listOfSentDates, aListLength)
+    val result = computeCutOffDates(listOfSentDates)
     result.head.cutOffDate should be(aDate.plusDays(1000 - 94))
   }
 
@@ -80,7 +89,7 @@ class NewslettersSpec extends AnyFlatSpec with Matchers {
         timestamp = aCampaignSentDate.timestamp.plusDays(dateOffset)
       )
     }
-    val result = newsletters.computeCutOffDates(listOfSentDates1 ++ listOfSentDates2, aListLength)
+    val result = computeCutOffDates(listOfSentDates1 ++ listOfSentDates2)
     result.head.cutOffDate should be(aDate.plusDays(1000 - 94))
     result(1).cutOffDate should be(aDate.plusDays(1000 - 61))
   }

--- a/src/test/scala/com/gu/newsletterlistcleanse/models/CleanseListSpec.scala
+++ b/src/test/scala/com/gu/newsletterlistcleanse/models/CleanseListSpec.scala
@@ -10,30 +10,30 @@ class CleanseListSpec extends AnyFlatSpec with Matchers {
   val shortList = List("a", "b", "c", "d", "e")
 
   "The CleanseList JSON conversion" should "handle an empty list" in {
-    val cleanseList: CleanseList = CleanseList("TestNewsletter", Nil)
-    cleanseList.asJson.noSpaces should be("{\"newsletterName\":\"TestNewsletter\",\"userIdList\":[]}")
+    val cleanseList: CleanseList = CleanseList("TestNewsletter", Nil, dryRun = true)
+    cleanseList.asJson.noSpaces should be("""{"newsletterName":"TestNewsletter","userIdList":[],"dryRun":true}""")
   }
 
   it should "handle a single list" in {
-    val cleanseList: CleanseList = CleanseList("TestNewsletter", List("a", "b", "c", "d", "e"))
-    cleanseList.asJson.noSpaces should be("{\"newsletterName\":\"TestNewsletter\",\"userIdList\":[\"a\",\"b\",\"c\",\"d\",\"e\"]}")
+    val cleanseList: CleanseList = CleanseList("TestNewsletter", List("a", "b", "c", "d", "e"), dryRun = true)
+    cleanseList.asJson.noSpaces should be("""{"newsletterName":"TestNewsletter","userIdList":["a","b","c","d","e"],"dryRun":true}""")
   }
 
   "The batch split logic" should "ignore an empty list" in {
-    val cleanseList: CleanseList = CleanseList("TestNewsletter", Nil)
+    val cleanseList: CleanseList = CleanseList("TestNewsletter", Nil, dryRun = true)
 
 
     cleanseList.getCleanseListBatches(100) should be(Nil)
   }
 
   it should "return a List of cleanseLists with Lists of users of length `usersPerMessage`" in {
-    val cleanseList: CleanseList = CleanseList("TestNewsletter", shortList)
+    val cleanseList: CleanseList = CleanseList("TestNewsletter", shortList, dryRun = true)
 
     cleanseList.getCleanseListBatches(2) should be(
       List(
-        CleanseList("TestNewsletter", List("a", "b")),
-        CleanseList("TestNewsletter", List("c", "d")),
-        CleanseList("TestNewsletter", List("e"))
+        CleanseList("TestNewsletter", List("a", "b"), dryRun = true),
+        CleanseList("TestNewsletter", List("c", "d"), dryRun = true),
+        CleanseList("TestNewsletter", List("e"), dryRun = true)
       )
     )
 


### PR DESCRIPTION
## What does this change?
- Adds a new dry-run flag. If the flag isn't provided, the run is assumed to be a dry-run
- The flag is passed from the first lambda to each next one as an extra attribute on the payload rather than a config. I'm still on two minds about it to be perfectly honest.

## How to test
We'll have to test that end-to end
- [ ] TODO: test locally
