### PR TITLE
Filter archive email addresses

### DIFF
--- a/src/main/scala/com/gu/newsletterlistcleanse/NewsletterConfig.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/NewsletterConfig.scala
@@ -3,13 +3,15 @@ package com.gu.newsletterlistcleanse
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.gu.{AppIdentity, AwsIdentity}
 import com.gu.conf.{ConfigurationLoader, SSMConfigurationLocation}
+import scala.collection.JavaConverters._
 
 case class NewsletterConfig(
   serviceAccount: String,
   projectId: String,
   brazeApiToken: String,
   cutOffSqsUrl: String,
-  cleanseListSqsUrl: String
+  cleanseListSqsUrl: String,
+  archiveFilterSet: Set[String]
 )
 
 object NewsletterConfig {
@@ -23,7 +25,8 @@ object NewsletterConfig {
       projectId = config.getString("projectId"),
       brazeApiToken = config.getString("brazeApiToken"),
       cutOffSqsUrl = config.getString("cutOffSqsUrl"),
-      cleanseListSqsUrl = config.getString("cleanseListSqsUrl")
+      cleanseListSqsUrl = config.getString("cleanseListSqsUrl"),
+      archiveFilterSet = config.getStringList("archiveFilterList").asScala.toSet
     )
   }
 }

--- a/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
@@ -25,6 +25,8 @@ class UpdateBrazeUsersLambda {
   val config: NewsletterConfig = NewsletterConfig.load(credentialProvider)
   val timeout: Duration = Duration(15, TimeUnit.MINUTES)
 
+  private val archiveFilterSet = config.archiveFilterSet
+
   def handler(sqsEvent: SQSEvent): Unit = {
     val env = Env()
     logger.info(s"Starting $env")
@@ -73,7 +75,7 @@ class UpdateBrazeUsersLambda {
 
     val brazeResponses: List[Future[Either[BrazeError, SimpleBrazeResponse]]] = for {
       cleanseList <- cleanseLists
-      filteredUserIdList = cleanseList.userIdList.toSet -- allInvalidUsers
+      filteredUserIdList = cleanseList.userIdList.toSet -- (allInvalidUsers ++ archiveFilterSet)
       batchedUserIds = filteredUserIdList.grouped(updateBatchSize)
       batch <- batchedUserIds
       newsletterName = cleanseList.newsletterName


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Remove Braze External IDs for the archive email addresses from any cleanse list. IDs should be stored in SSM.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Compiles and runs locally. Will need to test this more closely when doing dry runs to look at the removed User IDs, probably when doing the work to store removed users. We can check if these appear in the removed user list.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

External IDs are stored in SSM and not in the codebase directly.

