### PR TITLE
Automatically shut down the HTTP client at the end of a local execution

### DIFF
--- a/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeClient.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeClient.scala
@@ -16,7 +16,7 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
 
-object BrazeClient {
+class BrazeClient {
 
   private val timeout = 5000.seconds
 


### PR DESCRIPTION
This will only affect local runs, and ensures that we get the SBT prompt back after a local run.

 - Make the braze client a class rather than an object, this is to avoid having it remaining in memory in between executions
 - Shut down the HTTP client at the end of a local execution

The reason the SBT prompt wasn't coming back was because by default a Java program will continue to execute even if the main thread has terminated, so long as there are threads in the background. With one exception - not relevant to this case but interesting nonetheless -  the program will terminate if there are only [Daemon threads](https://docs.oracle.com/javase/7/docs/api/java/lang/Thread.html#setDaemon(boolean)).

With most HTTP clients a thread pool is started, and more often than not these aren't marked a Daemon. So most HTTP clients provide with a way to explicitly shut-down the thread pool. This only applies when running locally, as when running as a lambda function in the cloud we _want_ that pool to remain active so we don't have to pay the upfront cost of creating a thread pool and opening HTTP connections on each run of the function.