### PR TITLE
Add a dry-run flag in the config

### DIFF
--- a/src/main/scala/com/gu/newsletterlistcleanse/NewsletterConfig.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/NewsletterConfig.scala
@@ -11,7 +11,8 @@ case class NewsletterConfig(
   brazeApiToken: String,
   cutOffSqsUrl: String,
   cleanseListSqsUrl: String,
-  archiveFilterSet: Set[String]
+  archiveFilterSet: Set[String],
+  dryRun: Boolean
 )
 
 object NewsletterConfig {
@@ -26,7 +27,8 @@ object NewsletterConfig {
       brazeApiToken = config.getString("brazeApiToken"),
       cutOffSqsUrl = config.getString("cutOffSqsUrl"),
       cleanseListSqsUrl = config.getString("cleanseListSqsUrl"),
-      archiveFilterSet = config.getStringList("archiveFilterList").asScala.toSet
+      archiveFilterSet = config.getStringList("archiveFilterList").asScala.toSet,
+      dryRun = if (config.hasPathOrNull("dryRun")) config.getBoolean("dryRun") else true
     )
   }
 }

--- a/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
@@ -60,13 +60,18 @@ class UpdateBrazeUsersLambda {
     Future.sequence(allInvalidUserTasks).map(invalidUsers => invalidUsers.toEitherList.map(_.flatten))
   }
 
-  private def updateUsers(userIds: List[String], identityNewsletter: EmailNewsletter) = {
+  private def updateUsers(userIds: List[String], identityNewsletter: EmailNewsletter): Future[Either[BrazeError, SimpleBrazeResponse]] = {
     val timestamp: Instant = Instant.now()
     val requests = for {
       userId <- userIds
     } yield BrazeNewsletterSubscriptionsUpdate(userId, Map((identityNewsletter, false)))
 
-    BrazeClient.updateUser(config.brazeApiToken, UserTrackRequest(requests, timestamp))
+    if (!config.dryRun) {
+      BrazeClient.updateUser(config.brazeApiToken, UserTrackRequest(requests, timestamp))
+    } else {
+      logger.info(s"Dry-run: Would have updated a batch of ${userIds.length} users")
+      Future.successful(Right(SimpleBrazeResponse("success")))
+    }
   }
 
   private def sendBrazeUpdates(cleanseLists: List[CleanseList], allInvalidUsers: Set[String]): Future[Either[List[BrazeError], List[SimpleBrazeResponse]]] = {
@@ -87,6 +92,7 @@ class UpdateBrazeUsersLambda {
 
   def getBrazeResults(cleanseLists: List[CleanseList]): Future[Either[List[BrazeError], List[SimpleBrazeResponse]]] = {
     logger.info(s"Processing ${cleanseLists.map(_.newsletterName).mkString(", ")}")
+    if (config.dryRun) logger.info("Running in dry-run mode, won't update Braze")
     getAllInvalidUsers(cleanseLists)
       .flatMap {
         case Left(e) => Future.successful(Left(e))


### PR DESCRIPTION
This is the second attempt at this ticket. This time I'm implementing the Dry-Run flag, as a flag stored in the config.

It makes the change a whole lot easier to maintain, just slightly more inconvenient when switching it on and off, which I believe is acceptable.