### PR TITLE
Add week lag

### DIFF
--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
@@ -83,5 +83,6 @@ object TestGetCleanseList {
     val parsedJson = decode[NewsletterCutOff](json).right.get
     val getCleanseListLambda = new GetCleanseListLambda
     Await.result(getCleanseListLambda.process(List(parsedJson)), getCleanseListLambda.timeout)
+    getCleanseListLambda.sqsClient.shutdown()
   }
 }

--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCutOffDatesLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCutOffDatesLambda.scala
@@ -71,5 +71,6 @@ object TestGetCutOffDates {
     val getCutOffDatesLambda = new GetCutOffDatesLambda()
     val lambdaInput = GetCutOffDatesLambdaInput(Some(List("Editorial_AnimalsFarmed", "Editorial_TheLongRead")))
     Await.result(getCutOffDatesLambda.process(lambdaInput), getCutOffDatesLambda.timeout)
+    getCutOffDatesLambda.sqsClient.shutdown()
   }
 }

--- a/src/main/scala/com/gu/newsletterlistcleanse/db/BigQueryOperations.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/db/BigQueryOperations.scala
@@ -58,6 +58,7 @@ class BigQueryOperations(serviceAccount: String, projectId: String) extends Data
                 |    FROM
                 |      `datalake.braze_dispatch`
                 |    WHERE campaign_name IN UNNEST(@campaignNames)
+                |    AND DATE(timestamp) < DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)
                 |  )
                 |)
                 |WHERE rn <= @cutOffLength
@@ -88,6 +89,7 @@ class BigQueryOperations(serviceAccount: String, projectId: String) extends Data
                 |    FROM
                 |      `datalake.braze_dispatch`
                 |    WHERE campaign_name IN UNNEST(@campaignNames)
+                |    AND DATE(timestamp) < DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)
                 |  )
                 |)
                 |WHERE rn <= @cutOffLength


### PR DESCRIPTION
The tracking of openings is provided from Braze as a list of events. That list of events can potentially lag, and the job processing these events can also fail for potentially multiple days.

It's possible to measure this lag in the datalake by comparing the `event_date` and the `processed_date` of each record of the `braze_email_open` table. At the time of writing the maximum lag observed was 5 days, so I've added 7 days for safety.

So to be clear, this is fairly similar to running the same Job but one week in the past, as a safety to make sure we have had the time to ingest all the events.

Oh I've also added an explicit shutdown of the SQS client, for the same reason as https://github.com/guardian/newsletters-list-cleanse/pull/16