### PR TITLE
Store cleared users for future backup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-events" % "2.2.9",
   "com.amazonaws" % "aws-lambda-java-log4j2" % "1.2.0",
   "com.amazonaws" % "aws-java-sdk-sqs" % "1.11.842",
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.842",
   "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.13.3",
   "org.slf4j" % "slf4j-api" % "1.7.30",
   "com.google.cloud" % "google-cloud-bigquery" % "1.116.10",

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -230,25 +230,3 @@ Resources:
       FunctionName: !GetAtt GetCutOffDatesLambda.Arn
       Principal: events.amazonaws.com
       SourceArn: !GetAtt DailyEvent.Arn
-
-  CleanseListBackUpBucket:
-    Type: AWS::S3::Bucket
-    Properties:
-      BucketName: !Sub newsletter-cleanse-backup-bucket-${Stage}
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
-        DeletionPolicy: Retain
-      Tags:
-        - Key: Stage
-          Value: !Ref Stage
-        - Key: Stack
-          Value: !Ref Stack
-        - Key: App
-          Value: !Ref App

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -230,3 +230,31 @@ Resources:
       FunctionName: !GetAtt GetCutOffDatesLambda.Arn
       Principal: events.amazonaws.com
       SourceArn: !GetAtt DailyEvent.Arn
+
+  CleanseListBackUpBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub newsletter-cleanse-backup-bucket-${Stage}
+      DeletionPolicy: Retain
+      Tags:
+        - Key: Stage
+          Value: !Ref Stage
+        - Key: Stack
+          Value: !Ref Stack
+        - Key: App
+          Value: !Ref App
+
+  CleanseListBackUpBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket:
+        Ref: CleanseListBackUpBucket
+      PolicyDocument:
+        Statement:
+          Action:
+            - s3:GetObject
+            - s3:PutObject
+          Effect: Allow
+          Resource:
+            - !Sub arn:aws:s3:::newsletter-cleanse-backup-bucket-${Stage}
+          Principal: !GetAtt ExecutionRole.Arn

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -235,7 +235,16 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Sub newsletter-cleanse-backup-bucket-${Stage}
-      DeletionPolicy: Retain
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+        DeletionPolicy: Retain
       Tags:
         - Key: Stage
           Value: !Ref Stage
@@ -243,18 +252,3 @@ Resources:
           Value: !Ref Stack
         - Key: App
           Value: !Ref App
-
-  CleanseListBackUpBucketPolicy:
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      Bucket:
-        Ref: CleanseListBackUpBucket
-      PolicyDocument:
-        Statement:
-          Action:
-            - s3:GetObject
-            - s3:PutObject
-          Effect: Allow
-          Resource:
-            - !Sub arn:aws:s3:::newsletter-cleanse-backup-bucket-${Stage}
-          Principal: !GetAtt ExecutionRole.Arn

--- a/src/main/scala/com/gu/newsletterlistcleanse/NewsletterConfig.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/NewsletterConfig.scala
@@ -12,7 +12,8 @@ case class NewsletterConfig(
   cutOffSqsUrl: String,
   cleanseListSqsUrl: String,
   archiveFilterSet: Set[String],
-  dryRun: Boolean
+  dryRun: Boolean,
+  backupBucketName: String
 )
 
 object NewsletterConfig {
@@ -28,7 +29,8 @@ object NewsletterConfig {
       cutOffSqsUrl = config.getString("cutOffSqsUrl"),
       cleanseListSqsUrl = config.getString("cleanseListSqsUrl"),
       archiveFilterSet = config.getStringList("archiveFilterList").asScala.toSet,
-      dryRun = if (config.hasPathOrNull("dryRun")) config.getBoolean("dryRun") else true
+      dryRun = if (config.hasPathOrNull("dryRun")) config.getBoolean("dryRun") else true,
+      backupBucketName = config.getString("backupBucketName")
     )
   }
 }

--- a/src/main/scala/com/gu/newsletterlistcleanse/NewsletterConfig.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/NewsletterConfig.scala
@@ -13,7 +13,8 @@ case class NewsletterConfig(
   cleanseListSqsUrl: String,
   archiveFilterSet: Set[String],
   dryRun: Boolean,
-  backupBucketName: String
+  backupBucketName: String,
+  subscribeUsers: Boolean
 )
 
 object NewsletterConfig {
@@ -30,7 +31,8 @@ object NewsletterConfig {
       cleanseListSqsUrl = config.getString("cleanseListSqsUrl"),
       archiveFilterSet = config.getStringList("archiveFilterList").asScala.toSet,
       dryRun = if (config.hasPathOrNull("dryRun")) config.getBoolean("dryRun") else true,
-      backupBucketName = config.getString("backupBucketName")
+      backupBucketName = config.getString("backupBucketName"),
+      subscribeUsers = if (config.hasPathOrNull("subscribeUsers")) config.getBoolean("subscribeUsers") else false,
     )
   }
 }

--- a/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
@@ -67,7 +67,7 @@ class UpdateBrazeUsersLambda {
     val timestamp: Instant = Instant.now()
     val requests = for {
       userId <- userIds
-    } yield BrazeNewsletterSubscriptionsUpdate(userId, Map((identityNewsletter, false)))
+    } yield BrazeNewsletterSubscriptionsUpdate(userId, Map((identityNewsletter, config.subscribeUsers)))
 
     if (!config.dryRun) {
       brazeClient.updateUser(config.brazeApiToken, UserTrackRequest(requests, timestamp))

--- a/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeModels.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeModels.scala
@@ -80,17 +80,15 @@ object BrazeEvent {
 
 object BrazeSubscribeEvent {
 
-  def apply(externalId: String, sub: EmailNewsletter, timestamp: Instant, updateExistingOnlyField: Boolean = false): List[BrazeEvent] = {
+  def apply(externalId: String, sub: EmailNewsletter, isSubscribed: Boolean, timestamp: Instant, updateExistingOnlyField: Boolean = false): List[BrazeEvent] = {
     // Marketing need to be able to segment subscription events by campaign. To do this the campaign name must be in the name of the event,
     // (as braze can only segment by custom event name not property).
-    val newsletterEventName = s"${sub.brazeSubscribeEventNamePrefix}_unsubscribe_email_date"
-
-    val generalEventName = "EditorialUnsubscribe"
+    val newsletterEventName = if (isSubscribed) s"${sub.brazeSubscribeEventNamePrefix}_subscribe_email_date" else s"${sub.brazeSubscribeEventNamePrefix}_unsubscribe_email_date"
+    val generalEventName = if (isSubscribed) "EditorialSubscribe" else "EditorialUnsubscribe"
     List(
       BrazeEvent(externalId, generalEventName, timestamp.toString, BrazeEventProperties(sub.brazeSubscribeAttributeName), updateExistingOnlyField),
       BrazeEvent(externalId, newsletterEventName, timestamp.toString, BrazeEventProperties(sub.brazeSubscribeAttributeName), updateExistingOnlyField)
     )
-
   }
 }
 
@@ -100,8 +98,8 @@ object UserTrackRequest {
   def apply(userUpdates: List[BrazeNewsletterSubscriptionsUpdate], timestamp: Instant): UserTrackRequest = {
     val events = for {
       userUpdate <- userUpdates
-      (subscription, _) <- userUpdate.newsletterSubscriptions
-      event <- BrazeSubscribeEvent(userUpdate.externalId, subscription, timestamp)
+      (subscription, isSubscribed) <- userUpdate.newsletterSubscriptions
+      event <- BrazeSubscribeEvent(userUpdate.externalId, subscription, isSubscribed, timestamp)
     } yield event
 
     UserTrackRequest(userUpdates, events)


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Adds writing to an S3 bucket for each cleanse list. This should mean that, given a small change to the third lambda, we can re-run a job and undo any removals.

### TODO
- [x] Add subscribe option back into the third lambda
- [x] Finalise cloudformation
- [x] Fix the context object used in the `runMain` function

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
S3 bucket should be encrypted at rest.
## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
