### PR TITLE
Only trace the braze response in debug mode

### DIFF
--- a/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeClient.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeClient.scala
@@ -33,7 +33,9 @@ class BrazeClient {
     val results = block
 
     results.foreach {
-      case Right(successResult) => logger.info(s"BrazeClient success: $info $successResult")
+      case Right(successResult) =>
+        logger.info(s"BrazeClient success: $info")
+        logger.debug(s"BrazeClient result: $successResult")
       case Left(errorResult) => logger.error(s"BrazeClient failure: $info $errorResult")
     }
 


### PR DESCRIPTION
Just a tiny change to ensure we don't trace personal information if we don't need. I've left the log line in `debug` mode so when testing locally we can change the log level.