### PR TITLE
Give the lambda the right to write to S3

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -81,7 +81,7 @@ Resources:
               Effect: Allow
               Action:
                 - s3:PutObject
-              Resource: !Sub arn:aws:s3:::!{BackupBucket}/*
+              Resource: !Sub arn:aws:s3:::${BackupBucket}/*
 
   GetCutOffDatesLambda:
     Type: AWS::Lambda::Function

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -21,6 +21,9 @@ Parameters:
     Description: Bucket where RiffRaff uploads artifacts on deploy
     Type: String
     Default: identity-lambda
+  BackupBucket:
+    Description: Bucket where we temporarily store which users are removed from the mailing list
+    Type: String
 
 Resources:
   ExecutionRole:
@@ -72,6 +75,13 @@ Resources:
               Action:
                 - ssm:GetParametersByPath
               Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${Stack}/${App}/${Stage}
+        - PolicyName: s3
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - s3:PutObject
+              Resource: !Sub arn:aws:s3:::!{BackupBucket}/*
 
   GetCutOffDatesLambda:
     Type: AWS::Lambda::Function


### PR DESCRIPTION
## What does this change?
This changes the role assigned to the lambdas, such that it can write to the backup S3 bucket

Before deploying to prod, the template must be applied manually in the console as I'm adding a new parameter