### PR TITLE
Fix the event mapping

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -107,7 +107,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Sub newsletter-newsletter-cut-off-date-${Stage}
-      VisibilityTimeout: 100
+      VisibilityTimeout: 600
       MessageRetentionPeriod: 3600 # 1 hour
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt NewsletterCutOffDateDlq.Arn
@@ -167,7 +167,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Sub newsletter-cleanse-list-${Stage}
-      VisibilityTimeout: 100
+      VisibilityTimeout: 600
       MessageRetentionPeriod: 3600 # 1 hour
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt CleanseListDlq.Arn

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -200,7 +200,7 @@ Resources:
     Properties:
       BatchSize: 1
       Enabled: True
-      EventSourceArn: !GetAtt NewsletterCutOffDateQueue.Arn
+      EventSourceArn: !GetAtt CleanseListQueue.Arn
       FunctionName: !Sub newsletter-cleanse-update-braze-users-${Stage}
 
   UpdateBrazeUsersLambda:


### PR DESCRIPTION
That would explain why the third lambda wasn't running 😅 : both lambdas were reading from the first SQS queue.

This PR:
 - Fixes the Event mapping, ensuring it reads from the correct queue
 - Changes the timeout of the SQS queues to match the timeouts of the lambdas
