### PR TITLE
Handle no invalid user ids

### DIFF
--- a/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeClient.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeClient.scala
@@ -55,6 +55,7 @@ class BrazeClient {
 
     response.body match {
       case Left(requestError) =>
+        logger.error(s"Got HTTP ${response.code.code} from Braze", requestError)
         Left(BrazeError(response.code.code, requestError))
       case Right(body) =>
         parseResponse[T](body, response.code.code)
@@ -89,12 +90,10 @@ class BrazeClient {
         .send()
 
 
-      response.map(parseValidateResponse[ExportIdBrazeResponse]).map(parsedResponse =>
-        parsedResponse match {
-          case Left(error) => Left(error)
-          case Right(validResponse) => Right(validResponse.invalidUserIds)
-        }
-      )
+      response.map(parseValidateResponse[ExportIdBrazeResponse]).map {
+        case Left(error) => Left(error)
+        case Right(validResponse) => Right(validResponse.invalidUserIds.getOrElse(Nil))
+      }
     }
 
   }

--- a/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeClient.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeClient.scala
@@ -8,8 +8,8 @@ import sttp.client.asynchttpclient.future.AsyncHttpClientFutureBackend
 import scala.concurrent.duration._
 import io.circe.parser.decode
 import io.circe.syntax._
-import org.asynchttpclient.{AsyncHttpClient, DefaultAsyncHttpClientConfig}
-import org.asynchttpclient.Dsl.{asyncHttpClient, config}
+import org.asynchttpclient.DefaultAsyncHttpClientConfig
+import org.asynchttpclient.filter.ThrottleRequestFilter
 import sttp.client.asynchttpclient.WebSocketHandler
 
 import scala.concurrent.Future
@@ -19,10 +19,11 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class BrazeClient {
 
   private val timeout = 5000.seconds
+  private val concurrencyLimit = 3
 
   private val sttpOptions = SttpBackendOptions.connectionTimeout(timeout)
   private val adjustFunction: DefaultAsyncHttpClientConfig.Builder => DefaultAsyncHttpClientConfig.Builder =
-    (defaultConfig) => defaultConfig.setMaxConnections(3)
+    (defaultConfig) => defaultConfig.addRequestFilter(new ThrottleRequestFilter(concurrencyLimit)).setMaxConnections(concurrencyLimit)
   implicit val sttpBackend: SttpBackend[Future, Nothing, WebSocketHandler] = AsyncHttpClientFutureBackend
     .usingConfigBuilder(adjustFunction, sttpOptions)
 

--- a/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeModels.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/braze/BrazeModels.scala
@@ -21,7 +21,7 @@ object SimpleBrazeResponse {
   implicit val simpleBrazeResponseDecoder: Decoder[SimpleBrazeResponse] = deriveDecoder
 }
 
-case class ExportIdBrazeResponse(message: String, invalidUserIds: List[String],
+case class ExportIdBrazeResponse(message: String, invalidUserIds: Option[List[String]],
                                  users: List[Map[String,String]]) extends BrazeResponse {
   override def isSuccessful: Boolean = message == "success" || message == "queued"
 }


### PR DESCRIPTION
 - Set the `invalidUserIds` type to optional
 - Correctly throttle the amount of concurrent requests
 - Trace the HTTP code of the Braze response

Co-authored by @buck06191 