### PR TITLE
Set to the first Tuesday of the month

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -227,7 +227,7 @@ Resources:
     Type: AWS::Events::Rule
     Properties:
       Description: Event sent to process the previous day of data
-      ScheduleExpression: cron(14 3 * * ? *)
+      ScheduleExpression: cron(15 10 ? 1/1 TUE#1 *)
       State: DISABLED
       Targets:
         - Id: Lambda


### PR DESCRIPTION
A simple change to plan the job every first Tuesday at 10:15am.

The thinking being that's a likely time a dev will be around in case there's an alarm, quarter past so that we've had the time to finish our morning coffee / tea 😄 