### PR TITLE
Fix over-selection for users of Today UK

### DIFF
--- a/src/main/scala/com/gu/newsletterlistcleanse/db/BigQueryOperations.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/db/BigQueryOperations.scala
@@ -158,7 +158,7 @@ class BigQueryOperations(serviceAccount: String, projectId: String) extends Data
                 |  FROM `datalake.braze_email_open` AS open
                 |  WHERE
                 |    send.user_id = open.user_id
-                |    AND open.campaign_name = send.campaign_name
+                |    AND open.campaign_name in UNNEST(@campaignNames)
                 |    AND open.event_date >= DATE(@formattedDate)
                 |) AND exists (
                 |  SELECT 1


### PR DESCRIPTION
This fixes an issue observed in production where we over-selected (and therefore over-unsubscribed) users.
This was due to the fact the request would select users who read the weekdays *and* the weekend version of the newsletter over the last 3 months, where we wanted the weekdays *or* the weekend version of the newsletter.

The fix is pretty simple, don't join on the campaign name which will restrict which event we'll filter on, but re-inject the two campaign names in the request.

TODO
- [x] Test the request
- [x] Test locally
