### PR TITLE
Fetch newsletter list from idapi

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,8 @@ scalacOptions ++= Seq(
   "-deprecation",
   "-encoding", "UTF-8",
   "-target:jvm-1.8",
-  "-Ywarn-dead-code"
+  "-Ywarn-dead-code",
+  "-Ypartial-unification",
 )
 
 enablePlugins(RiffRaffArtifact)
@@ -38,7 +39,8 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-generic" % "0.12.3",
   "io.circe" %% "circe-parser"% "0.12.3",
   "com.softwaremill.sttp.client" %% "core" % "2.2.7",
-  "com.softwaremill.sttp.client" %% "async-http-client-backend-future" % "2.2.7"
+  "com.softwaremill.sttp.client" %% "async-http-client-backend-future" % "2.2.7",
+  "org.typelevel" %% "cats-core" % "2.1.1",
 )
 assemblyJarName := s"${name.value}.jar"
 assemblyMergeStrategy in assembly := {

--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
@@ -12,6 +12,7 @@ import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.amazonaws.services.sqs.model.SendMessageResult
 import com.gu.newsletterlistcleanse.db.{BigQueryOperations, DatabaseOperations}
 import com.gu.newsletterlistcleanse.models.{CleanseList, NewsletterCutOff}
+import com.gu.newsletterlistcleanse.services.Newsletters
 import com.gu.newsletterlistcleanse.sqs.{AwsSQSSend, SqsMessageParser}
 import com.gu.newsletterlistcleanse.sqs.AwsSQSSend.Payload
 import io.circe.parser._

--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCutOffDatesLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCutOffDatesLambda.scala
@@ -8,6 +8,7 @@ import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.amazonaws.services.sqs.model.SendMessageResult
 import com.gu.newsletterlistcleanse.db.{BigQueryOperations, DatabaseOperations}
 import com.gu.newsletterlistcleanse.models.NewsletterCutOff
+import com.gu.newsletterlistcleanse.services.Newsletters
 import com.gu.newsletterlistcleanse.sqs.AwsSQSSend
 import com.gu.newsletterlistcleanse.sqs.AwsSQSSend.Payload
 import org.slf4j.{Logger, LoggerFactory}
@@ -55,7 +56,7 @@ class GetCutOffDatesLambda {
     val env = Env()
     logger.info(s"Starting $env")
     val newslettersToProcess = if (lambdaInput.newslettersToProcess.nonEmpty) {
-      lambdaInput.newslettersToProcess.toList
+      Future.successful(lambdaInput.newslettersToProcess.toList)
     } else {
       newsletters.allNewsletters
     }

--- a/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
@@ -6,7 +6,7 @@ import java.util.concurrent.TimeUnit
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
 import com.gu.newsletterlistcleanse.EitherConverter.EitherList
-import com.gu.newsletterlistcleanse.Newsletters.getIdentityNewsletterFromName
+import com.gu.newsletterlistcleanse.services.Newsletters.getIdentityNewsletterFromName
 import com.gu.newsletterlistcleanse.services.{BrazeClient, BrazeError, BrazeNewsletterSubscriptionsUpdate, SimpleBrazeResponse, UserExportRequest, UserTrackRequest}
 import com.gu.newsletterlistcleanse.models.CleanseList
 import com.gu.identity.model.EmailNewsletter

--- a/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/UpdateBrazeUsersLambda.scala
@@ -7,7 +7,7 @@ import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
 import com.gu.newsletterlistcleanse.EitherConverter.EitherList
 import com.gu.newsletterlistcleanse.Newsletters.getIdentityNewsletterFromName
-import com.gu.newsletterlistcleanse.braze.{BrazeClient, BrazeError, BrazeNewsletterSubscriptionsUpdate, SimpleBrazeResponse, UserExportRequest, UserTrackRequest}
+import com.gu.newsletterlistcleanse.services.{BrazeClient, BrazeError, BrazeNewsletterSubscriptionsUpdate, SimpleBrazeResponse, UserExportRequest, UserTrackRequest}
 import com.gu.newsletterlistcleanse.models.CleanseList
 import com.gu.identity.model.EmailNewsletter
 import com.gu.newsletterlistcleanse.sqs.SqsMessageParser

--- a/src/main/scala/com/gu/newsletterlistcleanse/db/BigQueryOperations.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/db/BigQueryOperations.scala
@@ -8,7 +8,7 @@ import com.gu.newsletterlistcleanse.models.NewsletterCutOff
 import com.google.cloud.bigquery.{BigQuery, BigQueryOptions, FieldValueList, QueryJobConfiguration, QueryParameterValue}
 import com.google.auth.Credentials
 import com.google.auth.oauth2.ServiceAccountCredentials
-import com.gu.newsletterlistcleanse.Newsletters
+import com.gu.newsletterlistcleanse.services.Newsletters
 
 import scala.collection.JavaConverters._
 

--- a/src/main/scala/com/gu/newsletterlistcleanse/services/BrazeClient.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/services/BrazeClient.scala
@@ -3,13 +3,10 @@ package com.gu.newsletterlistcleanse.services
 import io.circe.Decoder
 import org.slf4j.{Logger, LoggerFactory}
 import sttp.client._
-import sttp.client.asynchttpclient.future.AsyncHttpClientFutureBackend
 
 import scala.concurrent.duration._
 import io.circe.parser.decode
 import io.circe.syntax._
-import org.asynchttpclient.DefaultAsyncHttpClientConfig
-import org.asynchttpclient.filter.ThrottleRequestFilter
 import sttp.client.asynchttpclient.WebSocketHandler
 
 import scala.concurrent.Future
@@ -18,14 +15,9 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class BrazeClient {
 
-  private val timeout = 5000.seconds
-  private val concurrencyLimit = 3
+  val timeout: FiniteDuration = 5000.seconds
 
-  private val sttpOptions = SttpBackendOptions.connectionTimeout(timeout)
-  private val adjustFunction: DefaultAsyncHttpClientConfig.Builder => DefaultAsyncHttpClientConfig.Builder =
-    (defaultConfig) => defaultConfig.addRequestFilter(new ThrottleRequestFilter(concurrencyLimit)).setMaxConnections(concurrencyLimit)
-  implicit val sttpBackend: SttpBackend[Future, Nothing, WebSocketHandler] = AsyncHttpClientFutureBackend
-    .usingConfigBuilder(adjustFunction, sttpOptions)
+  implicit val sttpBackend: SttpBackend[Future, Nothing, WebSocketHandler] = SttpFactory.createSttpBackend()
 
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
   val brazeEndpoint = "https://rest.fra-01.braze.eu"

--- a/src/main/scala/com/gu/newsletterlistcleanse/services/BrazeClient.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/services/BrazeClient.scala
@@ -15,7 +15,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class BrazeClient {
 
-  val timeout: FiniteDuration = 5000.seconds
+  val timeout: FiniteDuration = 5.seconds
 
   implicit val sttpBackend: SttpBackend[Future, Nothing, WebSocketHandler] = SttpFactory.createSttpBackend()
 

--- a/src/main/scala/com/gu/newsletterlistcleanse/services/BrazeClient.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/services/BrazeClient.scala
@@ -1,4 +1,4 @@
-package com.gu.newsletterlistcleanse.braze
+package com.gu.newsletterlistcleanse.services
 
 import io.circe.Decoder
 import org.slf4j.{Logger, LoggerFactory}

--- a/src/main/scala/com/gu/newsletterlistcleanse/services/BrazeModels.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/services/BrazeModels.scala
@@ -1,4 +1,4 @@
-package com.gu.newsletterlistcleanse.braze
+package com.gu.newsletterlistcleanse.services
 
 import java.time.Instant
 

--- a/src/main/scala/com/gu/newsletterlistcleanse/services/Newsletters.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/services/Newsletters.scala
@@ -40,6 +40,11 @@ class Newsletters {
       }
     }
 
+    def handleNon200(response: Response[Either[String, String]]): Either[String, String] = response.body match {
+      case Right(body) if (response.code.isSuccess) => Right(body)
+      case _ => Left(s"${response.code.code}: ${response.statusText}")
+    }
+
     val response = basicRequest
       .get(uri"https://idapi.theguardian.com/newsletters")
       .header("Origin", "https://www.theguardian.com")
@@ -47,7 +52,7 @@ class Newsletters {
       .send()
 
     for {
-      body <- EitherT(response.map(_.body))
+      body <- EitherT(response.map(handleNon200))
       parsedBody <- EitherT.fromEither[Future](parseBody(body))
     } yield parsedBody
   }

--- a/src/main/scala/com/gu/newsletterlistcleanse/services/Newsletters.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/services/Newsletters.scala
@@ -28,7 +28,7 @@ object Newsletter {
 }
 
 class Newsletters {
-  val timeout: FiniteDuration = 5000.seconds
+  val timeout: FiniteDuration = 5.seconds
 
   implicit val sttpBackend: SttpBackend[Future, Nothing, WebSocketHandler] = SttpFactory.createSttpBackend()
 

--- a/src/main/scala/com/gu/newsletterlistcleanse/services/Newsletters.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/services/Newsletters.scala
@@ -1,4 +1,4 @@
-package com.gu.newsletterlistcleanse
+package com.gu.newsletterlistcleanse.services
 
 import java.time.ZonedDateTime
 

--- a/src/main/scala/com/gu/newsletterlistcleanse/services/Newsletters.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/services/Newsletters.scala
@@ -2,13 +2,55 @@ package com.gu.newsletterlistcleanse.services
 
 import java.time.ZonedDateTime
 
+import cats.implicits._
+import cats.data.EitherT
 import com.gu.identity.model.{EmailNewsletter, EmailNewsletters}
 import com.gu.newsletterlistcleanse.db.ActiveListLength.getActiveListLength
 import com.gu.newsletterlistcleanse.db.{ActiveListLength, CampaignSentDate}
 import com.gu.newsletterlistcleanse.models.NewsletterCutOff
+import io.circe.Decoder
+import sttp.client.asynchttpclient.WebSocketHandler
+import sttp.client.{SttpBackend, basicRequest}
+
+import scala.concurrent.duration._
+import io.circe.parser.decode
+import io.circe.generic.semiauto._
+import sttp.client._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+
+case class Newsletter(brazeNewsletterName: String)
+
+object Newsletter {
+  implicit val newsletterDecoder: Decoder[Newsletter] = deriveDecoder[Newsletter]
+}
 
 class Newsletters {
-  def allNewsletters: List[String] = EmailNewsletters.allNewsletters.map(_.brazeNewsletterName)
+  val timeout: FiniteDuration = 5000.seconds
+
+  implicit val sttpBackend: SttpBackend[Future, Nothing, WebSocketHandler] = SttpFactory.createSttpBackend()
+
+  def fetchAllNewsletters(): EitherT[Future, String, List[String]] = {
+    def parseBody(bodyString: String): Either[String, List[String]] = {
+      decode[List[Newsletter]](bodyString) match {
+        case Left(error) => Left(error.getMessage)
+        case Right(body) => Right(body.map(_.brazeNewsletterName))
+      }
+    }
+
+    val response = basicRequest
+      .get(uri"https://idapi.theguardian.com/newsletters")
+      .header("Origin", "https://www.theguardian.com")
+      .readTimeout(timeout)
+      .send()
+
+    for {
+      body <- EitherT(response.map(_.body))
+      parsedBody <- EitherT.fromEither[Future](parseBody(body))
+    } yield parsedBody
+  }
 
   private val reverseChrono: Ordering[ZonedDateTime] = (x: ZonedDateTime, y: ZonedDateTime) => y.compareTo(x)
 

--- a/src/main/scala/com/gu/newsletterlistcleanse/services/SttpFactory.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/services/SttpFactory.scala
@@ -1,0 +1,24 @@
+package com.gu.newsletterlistcleanse.services
+
+import org.asynchttpclient.DefaultAsyncHttpClientConfig
+import org.asynchttpclient.filter.ThrottleRequestFilter
+import sttp.client.asynchttpclient.WebSocketHandler
+import sttp.client.asynchttpclient.future.AsyncHttpClientFutureBackend
+import sttp.client.{SttpBackend, SttpBackendOptions}
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.concurrent.duration.FiniteDuration
+
+object SttpFactory {
+
+  def createSttpBackend(timeout: FiniteDuration = 5000.seconds, concurrencyLimit: Int = 3): SttpBackend[Future, Nothing, WebSocketHandler] = {
+
+    val sttpOptions = SttpBackendOptions.connectionTimeout(timeout)
+    val adjustFunction: DefaultAsyncHttpClientConfig.Builder => DefaultAsyncHttpClientConfig.Builder =
+      _.addRequestFilter(new ThrottleRequestFilter(concurrencyLimit)).setMaxConnections(concurrencyLimit)
+
+    AsyncHttpClientFutureBackend.usingConfigBuilder(adjustFunction, sttpOptions)
+  }
+
+}

--- a/src/main/scala/com/gu/newsletterlistcleanse/services/SttpFactory.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/services/SttpFactory.scala
@@ -12,7 +12,7 @@ import scala.concurrent.duration.FiniteDuration
 
 object SttpFactory {
 
-  def createSttpBackend(timeout: FiniteDuration = 5000.seconds, concurrencyLimit: Int = 3): SttpBackend[Future, Nothing, WebSocketHandler] = {
+  def createSttpBackend(timeout: FiniteDuration = 5.seconds, concurrencyLimit: Int = 3): SttpBackend[Future, Nothing, WebSocketHandler] = {
 
     val sttpOptions = SttpBackendOptions.connectionTimeout(timeout)
     val adjustFunction: DefaultAsyncHttpClientConfig.Builder => DefaultAsyncHttpClientConfig.Builder =

--- a/src/test/scala/com/gu/newsletterlistcleanse/services/NewslettersSpec.scala
+++ b/src/test/scala/com/gu/newsletterlistcleanse/services/NewslettersSpec.scala
@@ -1,4 +1,4 @@
-package com.gu.newsletterlistcleanse
+package com.gu.newsletterlistcleanse.services
 
 import java.time.ZonedDateTime
 


### PR DESCRIPTION
The goal of this change is to stop using the identity models. We're not quite there yet, but this is a good point to stop and release the change.

In this PR:
 - Move the Braze classes into a `services` package
 - Extract the sTTP backend creation such that it can be shared
 - Import cats such that we get the convenience of using `EitherT` over `Future[Either[String, List[String]]]`
 - Implement an HTTP call to fetch the list of newsletters from the identity API
 - Handle possible error cases

We can't yet remove the identity API as I've realised we use the `brazeSubscribeAttributeName` later down the pipeline, and we haven't added it yet to this [PR](https://github.com/guardian/identity/pull/1852). I'm not sure yet how we'll handle it, but I'm sure we'll find a solution.

This change has been tested locally, but would probably deserve to be run in dry-run mode once