### PR TITLE
Use api for braze data end to end

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,6 @@ resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/pla
 
 libraryDependencies ++= Seq(
   "com.gu" %% "simple-configuration-ssm" % "1.5.2",
-  "com.gu.identity" %% "identity-model" % "3.228",
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.1",
   "com.amazonaws" % "aws-lambda-java-events" % "2.2.9",
   "com.amazonaws" % "aws-lambda-java-log4j2" % "1.2.0",

--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
@@ -43,7 +43,7 @@ class GetCleanseListLambda {
       case Right(newsletterCutOffs) =>
         Await.result(process(newsletterCutOffs, Some(context)), timeout)
       case Left(parseErrors) =>
-        parseErrors.foreach(e =>logger.error(e.getMessage))
+        parseErrors.foreach(e => logger.error(e.getMessage))
     }
   }
 
@@ -77,7 +77,8 @@ class GetCleanseListLambda {
       userIds = fetchCampaignCleanseList(campaignCutOff)
       cleanseList = CleanseList(
         campaignCutOff.newsletterName,
-        userIds
+        userIds,
+        campaignCutOff.brazeData
       )
       _ = logger.info(s"Found ${userIds.length} users of ${campaignCutOff.activeListLength} to remove from ${campaignCutOff.newsletterName}")
       _ = exportCleanseListToS3(cleanseList, env, contextOption)

--- a/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/GetCleanseListLambda.scala
@@ -96,7 +96,9 @@ class GetCleanseListLambda {
 
 object TestGetCleanseList {
   def main(args: Array[String]): Unit = {
-    val json = """{"newsletterName":"Editorial_GuardianTodayUK","cutOffDate":"2020-06-07T11:31:14Z[Europe/London]", "activeListLength": 1000}"""
+    val json =
+      """{"newsletterName":"Editorial_GuardianTodayUK","cutOffDate":"2020-06-07T11:31:14Z[Europe/London]", "activeListLength": 1000,
+        |"brazeData":{"brazeSubscribeAttributeName":"TodayUk_Subscribe_Email","brazeSubscribeEventNamePrefix":"today_uk"}}""".stripMargin
     val parsedJson = decode[NewsletterCutOff](json).right.get
     val getCleanseListLambda = new GetCleanseListLambda
     Await.result(getCleanseListLambda.process(List(parsedJson), None), getCleanseListLambda.timeout)

--- a/src/main/scala/com/gu/newsletterlistcleanse/models/CleanseList.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/models/CleanseList.scala
@@ -1,8 +1,7 @@
 package com.gu.newsletterlistcleanse.models
 
-import io.circe.{Decoder, Encoder, Json}
+import io.circe.{Decoder, Encoder}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
-import io.circe.syntax._
 
 
 case class CleanseList(newsletterName: String, userIdList: List[String], brazeData: BrazeData){
@@ -13,15 +12,6 @@ case class CleanseList(newsletterName: String, userIdList: List[String], brazeDa
 }
 
 object CleanseList {
-  implicit val cleanseListEncoder: Encoder[CleanseList] = new Encoder[CleanseList] {
-    override def apply(cl: CleanseList): Json = Json.obj(
-      ("newsletterName", cl.newsletterName.asJson),
-      ("userIdList", cl.userIdList.asJson),
-      ("brazeData", Json.obj(
-        ("brazeSubscribeAttributeName", cl.brazeData.brazeSubscribeAttributeName.asJson),
-        ("brazeSubscribeEventNamePrefix", cl.brazeData.brazeSubscribeEventNamePrefix.asJson)
-      ))
-    )
-  }
+  implicit val cleanseListEncoder: Encoder[CleanseList] = deriveEncoder
   implicit val cleanseListDecoder: Decoder[CleanseList] = deriveDecoder
 }

--- a/src/main/scala/com/gu/newsletterlistcleanse/models/CleanseList.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/models/CleanseList.scala
@@ -1,16 +1,27 @@
 package com.gu.newsletterlistcleanse.models
 
-import io.circe.{Encoder, Decoder}
-import io.circe.generic.semiauto.{deriveEncoder, deriveDecoder}
+import io.circe.{Decoder, Encoder, Json}
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.syntax._
 
-case class CleanseList(newsletterName: String, userIdList: List[String]){
+
+case class CleanseList(newsletterName: String, userIdList: List[String], brazeData: BrazeData){
   def getCleanseListBatches(usersPerMessage: Int): List[CleanseList] = {
     this.userIdList.grouped(usersPerMessage).toList
-      .map(chunk => CleanseList(this.newsletterName, chunk ))
+      .map(chunk => CleanseList(this.newsletterName, chunk, this.brazeData))
   }
 }
 
 object CleanseList {
-  implicit val cleanseListEncoder: Encoder[CleanseList] = deriveEncoder
+  implicit val cleanseListEncoder: Encoder[CleanseList] = new Encoder[CleanseList] {
+    override def apply(cl: CleanseList): Json = Json.obj(
+      ("newsletterName", cl.newsletterName.asJson),
+      ("userIdList", cl.userIdList.asJson),
+      ("brazeData", Json.obj(
+        ("brazeSubscribeAttributeName", cl.brazeData.brazeSubscribeAttributeName.asJson),
+        ("brazeSubscribeEventNamePrefix", cl.brazeData.brazeSubscribeEventNamePrefix.asJson)
+      ))
+    )
+  }
   implicit val cleanseListDecoder: Decoder[CleanseList] = deriveDecoder
 }

--- a/src/main/scala/com/gu/newsletterlistcleanse/models/NewsletterCutOff.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/models/NewsletterCutOff.scala
@@ -5,13 +5,25 @@ import java.time.ZonedDateTime
 import io.circe.{Encoder, Decoder}
 import io.circe.generic.semiauto.{deriveEncoder, deriveDecoder}
 
+case class BrazeData (
+  brazeSubscribeAttributeName: String,
+  brazeSubscribeEventNamePrefix: String
+)
+
+object BrazeData {
+  implicit val newsletterCutOffEncoder: Encoder[BrazeData] = deriveEncoder
+  implicit val newsletterCutOffDecoder: Decoder[BrazeData] = deriveDecoder
+}
 case class NewsletterCutOff(
   newsletterName: String,
   cutOffDate: ZonedDateTime,
-  activeListLength: Int
+  activeListLength: Int,
+  brazeData: BrazeData
 )
 
 object NewsletterCutOff {
+  def apply(newsletterName: String, cutOffDate: ZonedDateTime, activeListLength: Int) : (BrazeData => NewsletterCutOff)
+  = NewsletterCutOff(newsletterName, cutOffDate, activeListLength, _: BrazeData)
   implicit val newsletterCutOffEncoder: Encoder[NewsletterCutOff] = deriveEncoder
   implicit val newsletterCutOffDecoder: Decoder[NewsletterCutOff] = deriveDecoder
 }

--- a/src/main/scala/com/gu/newsletterlistcleanse/models/NewsletterCutOff.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/models/NewsletterCutOff.scala
@@ -14,16 +14,24 @@ object BrazeData {
   implicit val newsletterCutOffEncoder: Encoder[BrazeData] = deriveEncoder
   implicit val newsletterCutOffDecoder: Decoder[BrazeData] = deriveDecoder
 }
+
 case class NewsletterCutOff(
   newsletterName: String,
   cutOffDate: ZonedDateTime,
-  activeListLength: Int,
-  brazeData: BrazeData
+  activeListLength: Int
 )
 
 object NewsletterCutOff {
-  def apply(newsletterName: String, cutOffDate: ZonedDateTime, activeListLength: Int) : (BrazeData => NewsletterCutOff)
-  = NewsletterCutOff(newsletterName, cutOffDate, activeListLength, _: BrazeData)
   implicit val newsletterCutOffEncoder: Encoder[NewsletterCutOff] = deriveEncoder
   implicit val newsletterCutOffDecoder: Decoder[NewsletterCutOff] = deriveDecoder
+}
+
+
+case class NewsletterCutOffWithBraze(
+  newsletterCutOff: NewsletterCutOff,
+  brazeData: BrazeData
+)
+object NewsletterCutOffWithBraze {
+  implicit val newsletterCutOffWithBrazeEncoder: Encoder[NewsletterCutOffWithBraze] = deriveEncoder
+  implicit val newsletterCutOffWithBrazeDecoder: Decoder[NewsletterCutOffWithBraze] = deriveDecoder
 }

--- a/src/main/scala/com/gu/newsletterlistcleanse/services/BrazeModels.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/services/BrazeModels.scala
@@ -1,7 +1,6 @@
 package com.gu.newsletterlistcleanse.services
 
 import java.time.Instant
-import com.gu.identity.model.{EmailNewsletter, EmailNewsletters}
 import com.gu.newsletterlistcleanse.models.BrazeData
 import sttp.client._
 import io.circe.{Decoder, Encoder, Json}

--- a/src/main/scala/com/gu/newsletterlistcleanse/services/BrazeModels.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/services/BrazeModels.scala
@@ -1,8 +1,8 @@
 package com.gu.newsletterlistcleanse.services
 
 import java.time.Instant
-
 import com.gu.identity.model.{EmailNewsletter, EmailNewsletters}
+import com.gu.newsletterlistcleanse.models.BrazeData
 import sttp.client._
 import io.circe.{Decoder, Encoder, Json}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
@@ -38,7 +38,7 @@ object BrazeError {
 }
 
 case class BrazeNewsletterSubscriptionsUpdate(externalId: String,
-                                              newsletterSubscriptions: Map[EmailNewsletter, Boolean])
+                                              newsletterSubscriptions: Map[BrazeData, Boolean])
 
 object BrazeNewsletterSubscriptionsUpdate {
   implicit val subscriptionUpdateEncoder: Encoder[BrazeNewsletterSubscriptionsUpdate] =
@@ -46,13 +46,13 @@ object BrazeNewsletterSubscriptionsUpdate {
       override def apply(update: BrazeNewsletterSubscriptionsUpdate): Json = {
         val jsonSubs = update.newsletterSubscriptions.map {
           // This case only relevant whilst migrating email_subscribe_today_uk custom attribute
-          case (newsLetter: EmailNewsletter, isSubscribed) if newsLetter == EmailNewsletters.guardianTodayUk =>
+          case (brazeData, isSubscribed) if brazeData.brazeSubscribeAttributeName == "TodayUk_Subscribe_Email" =>
             Map(
-              newsLetter.brazeSubscribeAttributeName -> Json.fromBoolean(isSubscribed),
+              brazeData.brazeSubscribeAttributeName -> Json.fromBoolean(isSubscribed),
               "email_subscribe_today_uk" -> Json.fromBoolean(isSubscribed)
             )
-          case (newsLetter, isSubscribed) =>
-            Map(newsLetter.brazeSubscribeAttributeName -> Json.fromBoolean(isSubscribed))
+          case (brazeData, isSubscribed) =>
+            Map(brazeData.brazeSubscribeAttributeName -> Json.fromBoolean(isSubscribed))
         }.fold(Map.empty)(_ ++ _)
         (jsonSubs ++ Map("external_id" -> Json.fromString(update.externalId))).asJson
       }
@@ -80,14 +80,14 @@ object BrazeEvent {
 
 object BrazeSubscribeEvent {
 
-  def apply(externalId: String, sub: EmailNewsletter, isSubscribed: Boolean, timestamp: Instant, updateExistingOnlyField: Boolean = false): List[BrazeEvent] = {
+  def apply(externalId: String, brazeData: BrazeData, isSubscribed: Boolean, timestamp: Instant, updateExistingOnlyField: Boolean = false): List[BrazeEvent] = {
     // Marketing need to be able to segment subscription events by campaign. To do this the campaign name must be in the name of the event,
     // (as braze can only segment by custom event name not property).
-    val newsletterEventName = if (isSubscribed) s"${sub.brazeSubscribeEventNamePrefix}_subscribe_email_date" else s"${sub.brazeSubscribeEventNamePrefix}_unsubscribe_email_date"
+    val newsletterEventName = if (isSubscribed) s"${brazeData.brazeSubscribeEventNamePrefix}_subscribe_email_date" else s"${brazeData.brazeSubscribeEventNamePrefix}_unsubscribe_email_date"
     val generalEventName = if (isSubscribed) "EditorialSubscribe" else "EditorialUnsubscribe"
     List(
-      BrazeEvent(externalId, generalEventName, timestamp.toString, BrazeEventProperties(sub.brazeSubscribeAttributeName), updateExistingOnlyField),
-      BrazeEvent(externalId, newsletterEventName, timestamp.toString, BrazeEventProperties(sub.brazeSubscribeAttributeName), updateExistingOnlyField)
+      BrazeEvent(externalId, generalEventName, timestamp.toString, BrazeEventProperties(brazeData.brazeSubscribeAttributeName), updateExistingOnlyField),
+      BrazeEvent(externalId, newsletterEventName, timestamp.toString, BrazeEventProperties(brazeData.brazeSubscribeAttributeName), updateExistingOnlyField)
     )
   }
 }
@@ -98,8 +98,8 @@ object UserTrackRequest {
   def apply(userUpdates: List[BrazeNewsletterSubscriptionsUpdate], timestamp: Instant): UserTrackRequest = {
     val events = for {
       userUpdate <- userUpdates
-      (subscription, isSubscribed) <- userUpdate.newsletterSubscriptions
-      event <- BrazeSubscribeEvent(userUpdate.externalId, subscription, isSubscribed, timestamp)
+      (brazeData, isSubscribed) <- userUpdate.newsletterSubscriptions
+      event <- BrazeSubscribeEvent(userUpdate.externalId, brazeData, isSubscribed, timestamp)
     } yield event
 
     UserTrackRequest(userUpdates, events)

--- a/src/main/scala/com/gu/newsletterlistcleanse/services/Newsletters.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/services/Newsletters.scala
@@ -5,7 +5,7 @@ import cats.implicits._
 import cats.data.EitherT
 import com.gu.newsletterlistcleanse.db.ActiveListLength.getActiveListLength
 import com.gu.newsletterlistcleanse.db.{ActiveListLength, CampaignSentDate}
-import com.gu.newsletterlistcleanse.models.{BrazeData, NewsletterCutOff}
+import com.gu.newsletterlistcleanse.models.NewsletterCutOff
 import io.circe.Decoder
 import sttp.client.asynchttpclient.WebSocketHandler
 import sttp.client.{SttpBackend, basicRequest}
@@ -65,12 +65,14 @@ class Newsletters {
 
   private val reverseChrono: Ordering[ZonedDateTime] = (x: ZonedDateTime, y: ZonedDateTime) => y.compareTo(x)
 
-  def computeCutOffDates(campaignSentDates: List[CampaignSentDate],
-    listLengths: List[ActiveListLength]): List[BrazeData => NewsletterCutOff] = {
+  def computeCutOffDates(
+    campaignSentDates: List[CampaignSentDate],
+    listLengths: List[ActiveListLength]
+  ): List[NewsletterCutOff] = {
 
     def extractCutOffBasedOnCampaign(
       campaignName: String,
-      sentDates: List[CampaignSentDate]): Option[BrazeData => NewsletterCutOff] =
+      sentDates: List[CampaignSentDate]): Option[NewsletterCutOff] =
       for {
         unOpenCount <- Newsletters.cleansingPolicy.get(campaignName)
         activeCount = getActiveListLength(listLengths, campaignName)

--- a/src/main/scala/com/gu/newsletterlistcleanse/services/Newsletters.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/services/Newsletters.scala
@@ -1,13 +1,11 @@
 package com.gu.newsletterlistcleanse.services
 
 import java.time.ZonedDateTime
-
 import cats.implicits._
 import cats.data.EitherT
-import com.gu.identity.model.{EmailNewsletter, EmailNewsletters}
 import com.gu.newsletterlistcleanse.db.ActiveListLength.getActiveListLength
 import com.gu.newsletterlistcleanse.db.{ActiveListLength, CampaignSentDate}
-import com.gu.newsletterlistcleanse.models.NewsletterCutOff
+import com.gu.newsletterlistcleanse.models.{BrazeData, NewsletterCutOff}
 import io.circe.Decoder
 import sttp.client.asynchttpclient.WebSocketHandler
 import sttp.client.{SttpBackend, basicRequest}
@@ -21,7 +19,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 
-case class Newsletter(brazeNewsletterName: String)
+case class Newsletter(brazeNewsletterName: String, brazeSubscribeAttributeName: String, brazeSubscribeEventNamePrefix: String)
 
 object Newsletter {
   implicit val newsletterDecoder: Decoder[Newsletter] = deriveDecoder[Newsletter]
@@ -32,11 +30,19 @@ class Newsletters {
 
   implicit val sttpBackend: SttpBackend[Future, Nothing, WebSocketHandler] = SttpFactory.createSttpBackend()
 
-  def fetchAllNewsletters(): EitherT[Future, String, List[String]] = {
-    def parseBody(bodyString: String): Either[String, List[String]] = {
+  def filterNewsletters(allNewsletters: List[Newsletter], filterList: List[String] = Nil): List[Newsletter] =
+    filterList match {
+      case Nil =>
+        allNewsletters
+      case _ =>
+        allNewsletters.filter(newsletter => filterList.contains(newsletter.brazeNewsletterName))
+    }
+
+  def fetchNewsletters(filterList: List[String] = Nil): EitherT[Future, String, List[Newsletter]] = {
+    def parseBody(bodyString: String): Either[String, List[Newsletter]] = {
       decode[List[Newsletter]](bodyString) match {
         case Left(error) => Left(error.getMessage)
-        case Right(body) => Right(body.map(_.brazeNewsletterName))
+        case Right(body) => Right(filterNewsletters(body, filterList))
       }
     }
 
@@ -59,22 +65,25 @@ class Newsletters {
 
   private val reverseChrono: Ordering[ZonedDateTime] = (x: ZonedDateTime, y: ZonedDateTime) => y.compareTo(x)
 
-  def computeCutOffDates(campaignSentDates: List[CampaignSentDate], listLengths: List[ActiveListLength]): List[NewsletterCutOff] = {
+  def computeCutOffDates(campaignSentDates: List[CampaignSentDate],
+    listLengths: List[ActiveListLength]): List[BrazeData => NewsletterCutOff] = {
 
-    def extractCutOffBasedOnCampaign(campaignName: String, sentDates: List[CampaignSentDate]): Option[NewsletterCutOff] = for {
-
-      unOpenCount <- Newsletters.cleansingPolicy.get(campaignName)
-      activeCount = getActiveListLength(listLengths, campaignName)
-      cutOff <- sentDates
-        .sortBy(_.timestamp)(reverseChrono)
-        .drop(unOpenCount - 1)
-        .headOption
-        .map(send => NewsletterCutOff(campaignName, send.timestamp, activeCount))
-    } yield cutOff
+    def extractCutOffBasedOnCampaign(
+      campaignName: String,
+      sentDates: List[CampaignSentDate]): Option[BrazeData => NewsletterCutOff] =
+      for {
+        unOpenCount <- Newsletters.cleansingPolicy.get(campaignName)
+        activeCount = getActiveListLength(listLengths, campaignName)
+        cutOff <- sentDates
+          .sortBy(_.timestamp)(reverseChrono)
+          .drop(unOpenCount - 1)
+          .headOption
+          .map(send => NewsletterCutOff(campaignName, send.timestamp, activeCount))
+      } yield cutOff
 
     campaignSentDates.groupBy(_.campaignName)
       .toList
-      .flatMap { case (campaignName, sentDates) => extractCutOffBasedOnCampaign(campaignName, sentDates) }
+      .flatMap { case (campaignName, sentDates ) => extractCutOffBasedOnCampaign(campaignName, sentDates) }
   }
 }
 
@@ -137,7 +146,4 @@ object Newsletters {
 
   val guardianTodayUK = "Editorial_GuardianTodayUK"
   val guardianTodayUKCampaigns = List("Editorial_GuardianTodayUK_Weekend", "Editorial_GuardianTodayUK_Weekdays")
-
-  def getIdentityNewsletterFromName(newsletterName: String): Option[EmailNewsletter] =
-    EmailNewsletters.allNewsletters.find(_.brazeNewsletterName == newsletterName)
 }

--- a/src/test/scala/com/gu/newsletterlistcleanse/models/CleanseListSpec.scala
+++ b/src/test/scala/com/gu/newsletterlistcleanse/models/CleanseListSpec.scala
@@ -1,39 +1,59 @@
 package com.gu.newsletterlistcleanse.models
 
+import com.gu.newsletterlistcleanse.models
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import io.circe.syntax._
+import io.circe.parser.decode
 
 
 class CleanseListSpec extends AnyFlatSpec with Matchers {
 
   val shortList = List("a", "b", "c", "d", "e")
 
+  val testBrazeData: BrazeData = BrazeData("testAttribute", "testEventName")
+
   "The CleanseList JSON conversion" should "handle an empty list" in {
-    val cleanseList: CleanseList = CleanseList("TestNewsletter", Nil)
-    cleanseList.asJson.noSpaces should be("{\"newsletterName\":\"TestNewsletter\",\"userIdList\":[]}")
+    val cleanseList: CleanseList = CleanseList("TestNewsletter", Nil, testBrazeData)
+    cleanseList.asJson.noSpaces should be("{\"newsletterName\":\"TestNewsletter\",\"userIdList\":[]," +
+      "\"brazeData\":{\"brazeSubscribeAttributeName\":\"testAttribute\",\"brazeSubscribeEventNamePrefix\":\"testEventName\"}}")
   }
 
   it should "handle a single list" in {
-    val cleanseList: CleanseList = CleanseList("TestNewsletter", List("a", "b", "c", "d", "e"))
-    cleanseList.asJson.noSpaces should be("{\"newsletterName\":\"TestNewsletter\",\"userIdList\":[\"a\",\"b\",\"c\",\"d\",\"e\"]}")
+    val cleanseList: CleanseList = CleanseList("TestNewsletter", List("a", "b", "c", "d", "e"), testBrazeData)
+    cleanseList.asJson.noSpaces should be("{\"newsletterName\":\"TestNewsletter\",\"userIdList\":[\"a\",\"b\",\"c\",\"d\",\"e\"]," +
+      "\"brazeData\":{\"brazeSubscribeAttributeName\":\"testAttribute\",\"brazeSubscribeEventNamePrefix\":\"testEventName\"}}")
+  }
+
+  it should "decode an empty list correctly" in {
+    val jsonString: String = "{\"newsletterName\":\"TestNewsletter\",\"userIdList\":[]," +
+      "\"brazeData\":{\"brazeSubscribeAttributeName\":\"testAttribute\",\"brazeSubscribeEventNamePrefix\":\"testEventName\"}}"
+    val cleanseList: CleanseList = CleanseList("TestNewsletter", Nil, testBrazeData)
+    decode[CleanseList](jsonString) should be(Right(cleanseList))
+  }
+
+  it should "decode a single list correctly" in {
+    val jsonString: String = "{\"newsletterName\":\"TestNewsletter\",\"userIdList\":[\"a\",\"b\",\"c\",\"d\",\"e\"]," +
+      "\"brazeData\":{\"brazeSubscribeAttributeName\": \"testAttribute\", \"brazeSubscribeEventNamePrefix\": \"testEventName\"}}"
+    val cleanseList: CleanseList = CleanseList("TestNewsletter", List("a", "b", "c", "d", "e"), testBrazeData)
+    decode[CleanseList](jsonString) should be(Right(cleanseList))
   }
 
   "The batch split logic" should "ignore an empty list" in {
-    val cleanseList: CleanseList = CleanseList("TestNewsletter", Nil)
+    val cleanseList: CleanseList = CleanseList("TestNewsletter", Nil, testBrazeData)
 
 
     cleanseList.getCleanseListBatches(100) should be(Nil)
   }
 
   it should "return a List of cleanseLists with Lists of users of length `usersPerMessage`" in {
-    val cleanseList: CleanseList = CleanseList("TestNewsletter", shortList)
+    val cleanseList: CleanseList = CleanseList("TestNewsletter", shortList, testBrazeData)
 
     cleanseList.getCleanseListBatches(2) should be(
       List(
-        CleanseList("TestNewsletter", List("a", "b")),
-        CleanseList("TestNewsletter", List("c", "d")),
-        CleanseList("TestNewsletter", List("e"))
+        CleanseList("TestNewsletter", List("a", "b"), testBrazeData),
+        CleanseList("TestNewsletter", List("c", "d"), testBrazeData),
+        CleanseList("TestNewsletter", List("e"),testBrazeData)
       )
     )
 

--- a/src/test/scala/com/gu/newsletterlistcleanse/services/NewslettersSpec.scala
+++ b/src/test/scala/com/gu/newsletterlistcleanse/services/NewslettersSpec.scala
@@ -1,8 +1,8 @@
 package com.gu.newsletterlistcleanse.services
 
 import java.time.ZonedDateTime
-
 import com.gu.newsletterlistcleanse.db.{ActiveListLength, CampaignSentDate}
+import com.gu.newsletterlistcleanse.models.BrazeData
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -12,10 +12,16 @@ class NewslettersSpec extends AnyFlatSpec with Matchers {
 
   val newsletters = new Newsletters
   val aDate: ZonedDateTime = ZonedDateTime.parse("2020-01-01T00:00:00Z")
+  val testBrazeData: BrazeData = BrazeData("test_attribute_name", "test_event_prefix")
   val aCampaignSentDate: CampaignSentDate = CampaignSentDate(
     campaignId = "1fc37a77-e6ec-4549-a908-f4b7a04a13be",
     campaignName = "Editorial_GuardianTodayUK",
     timestamp = aDate
+  )
+
+  val testAllNewsletters = List(Newsletter("test1", "testAttribute", "testEventName"),
+    Newsletter("test2", "testAttribute", "testEventName"),
+    Newsletter("test3", "testAttribute", "testEventName")
   )
 
   val aListLength: List[ActiveListLength] = List(
@@ -40,7 +46,7 @@ class NewslettersSpec extends AnyFlatSpec with Matchers {
       aCampaignSentDate.copy(timestamp = aCampaignSentDate.timestamp.plusDays(dateOffset))
     }
     val result = newsletters.computeCutOffDates(listOfSentDates, aListLength)
-    result.head.cutOffDate should be(aDate)
+    result.head(testBrazeData).cutOffDate should be(aDate)
   }
 
   it should "ignore a newsletter that hasn't got a cleansing policy yet" in {
@@ -59,7 +65,7 @@ class NewslettersSpec extends AnyFlatSpec with Matchers {
       aCampaignSentDate.copy(timestamp = aCampaignSentDate.timestamp.plusDays(dateOffset))
     }
     val result = newsletters.computeCutOffDates(listOfSentDates, aListLength)
-    result.head.cutOffDate should be(aDate.plusDays(1000 - 94))
+    result.head(testBrazeData).cutOffDate should be(aDate.plusDays(1000 - 94))
   }
 
   it should "pick the 94th date of the campaignSentDate, regardless of the order of the rows returned by the DB" in {
@@ -67,7 +73,7 @@ class NewslettersSpec extends AnyFlatSpec with Matchers {
       aCampaignSentDate.copy(timestamp = aCampaignSentDate.timestamp.plusDays(dateOffset))
     }
     val result = newsletters.computeCutOffDates(listOfSentDates, aListLength)
-    result.head.cutOffDate should be(aDate.plusDays(1000 - 94))
+    result.head(testBrazeData).cutOffDate should be(aDate.plusDays(1000 - 94))
   }
 
   it should "compute no matter how many campaigns are being sent" in {
@@ -81,8 +87,16 @@ class NewslettersSpec extends AnyFlatSpec with Matchers {
       )
     }
     val result = newsletters.computeCutOffDates(listOfSentDates1 ++ listOfSentDates2, aListLength)
-    result.head.cutOffDate should be(aDate.plusDays(1000 - 94))
-    result(1).cutOffDate should be(aDate.plusDays(1000 - 61))
+    result.head(testBrazeData).cutOffDate should be(aDate.plusDays(1000 - 94))
+    result(1)(testBrazeData).cutOffDate should be(aDate.plusDays(1000 - 61))
+  }
+
+  "The fetchNewsletters logic" should "return all Newsletters if no selection is passed" in {
+        newsletters.filterNewsletters(testAllNewsletters).length should be(3)
+  }
+
+  it should "return a filtered set of newsletters if a filterSelection is passed" in {
+    newsletters.filterNewsletters(testAllNewsletters, List("test1")).length should be(1)
   }
 
 }

--- a/src/test/scala/com/gu/newsletterlistcleanse/services/NewslettersSpec.scala
+++ b/src/test/scala/com/gu/newsletterlistcleanse/services/NewslettersSpec.scala
@@ -46,7 +46,7 @@ class NewslettersSpec extends AnyFlatSpec with Matchers {
       aCampaignSentDate.copy(timestamp = aCampaignSentDate.timestamp.plusDays(dateOffset))
     }
     val result = newsletters.computeCutOffDates(listOfSentDates, aListLength)
-    result.head(testBrazeData).cutOffDate should be(aDate)
+    result.head.cutOffDate should be(aDate)
   }
 
   it should "ignore a newsletter that hasn't got a cleansing policy yet" in {
@@ -65,7 +65,7 @@ class NewslettersSpec extends AnyFlatSpec with Matchers {
       aCampaignSentDate.copy(timestamp = aCampaignSentDate.timestamp.plusDays(dateOffset))
     }
     val result = newsletters.computeCutOffDates(listOfSentDates, aListLength)
-    result.head(testBrazeData).cutOffDate should be(aDate.plusDays(1000 - 94))
+    result.head.cutOffDate should be(aDate.plusDays(1000 - 94))
   }
 
   it should "pick the 94th date of the campaignSentDate, regardless of the order of the rows returned by the DB" in {
@@ -73,7 +73,7 @@ class NewslettersSpec extends AnyFlatSpec with Matchers {
       aCampaignSentDate.copy(timestamp = aCampaignSentDate.timestamp.plusDays(dateOffset))
     }
     val result = newsletters.computeCutOffDates(listOfSentDates, aListLength)
-    result.head(testBrazeData).cutOffDate should be(aDate.plusDays(1000 - 94))
+    result.head.cutOffDate should be(aDate.plusDays(1000 - 94))
   }
 
   it should "compute no matter how many campaigns are being sent" in {
@@ -87,8 +87,8 @@ class NewslettersSpec extends AnyFlatSpec with Matchers {
       )
     }
     val result = newsletters.computeCutOffDates(listOfSentDates1 ++ listOfSentDates2, aListLength)
-    result.head(testBrazeData).cutOffDate should be(aDate.plusDays(1000 - 94))
-    result(1)(testBrazeData).cutOffDate should be(aDate.plusDays(1000 - 61))
+    result.head.cutOffDate should be(aDate.plusDays(1000 - 94))
+    result(1).cutOffDate should be(aDate.plusDays(1000 - 61))
   }
 
   "The fetchNewsletters logic" should "return all Newsletters if no selection is passed" in {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
As part of the move to use IDAPI for all of the Newsletters information we needed to add in the ability to pass the Braze information down from the initial call in the first lambda to the end where it will then be used.

This depends on https://github.com/guardian/identity/pull/1855 and https://github.com/guardian/identity/pull/1856 to be merged before it will work.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Tested locally using local API. Also updated Unit Tests.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
List Cleanse still works and we can update the data model without a full release of Identity.
