### PR TITLE
Remove Bintray resolver and bump dependency version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,10 +21,8 @@ scalacOptions ++= Seq(
 
 enablePlugins(RiffRaffArtifact)
 
-resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
-
 libraryDependencies ++= Seq(
-  "com.gu" %% "simple-configuration-ssm" % "1.5.2",
+  "com.gu" %% "simple-configuration-ssm" % "1.5.6",
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.1",
   "com.amazonaws" % "aws-lambda-java-events" % "2.2.9",
   "com.amazonaws" % "aws-lambda-java-log4j2" % "1.2.0",

--- a/src/main/scala/com/gu/newsletterlistcleanse/Lambda.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/Lambda.scala
@@ -13,6 +13,7 @@ import com.gu.newsletterlistcleanse.db.{BigQueryOperations, DatabaseOperations}
 import com.gu.newsletterlistcleanse.models.Newsletter
 import com.gu.newsletterlistcleanse.services.{BrazeUsersService, CleanseListService, CutOffDatesService, NewslettersApiClient, ReportService}
 import org.slf4j.{Logger, LoggerFactory}
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 
 import scala.beans.BeanProperty
 import scala.concurrent.{Await, Future}
@@ -37,8 +38,10 @@ class Lambda {
 
   val timeout: Duration = Duration(15, TimeUnit.MINUTES)
 
-  val credentialProvider: AWSCredentialsProvider = new NewsletterSQSAWSCredentialProvider()
-  val config: NewsletterConfig = NewsletterConfig.load(credentialProvider)
+  val credentialProvider: AWSCredentialsProvider = NewsletterSQSAWSCredentialProvider.credentialsProviderV1
+  val credentialProviderV2: AwsCredentialsProvider = NewsletterSQSAWSCredentialProvider.credentialsProviderV2
+
+  val config: NewsletterConfig = NewsletterConfig.load(credentialProviderV2)
   val s3Client: AmazonS3 = AmazonS3ClientBuilder.standard
     .withCredentials(credentialProvider)
     .withRegion(Regions.EU_WEST_1)

--- a/src/main/scala/com/gu/newsletterlistcleanse/NewsletterAWSCredentialProvider.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/NewsletterAWSCredentialProvider.scala
@@ -2,7 +2,18 @@ package com.gu.newsletterlistcleanse
 
 import com.amazonaws.auth.{AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain}
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import software.amazon.awssdk.auth.credentials.{
+  AwsCredentialsProvider => AwsCredentialsProviderV2,
+  ProfileCredentialsProvider => ProfileCredentialsProviderV2,
+}
 
-class NewsletterSQSAWSCredentialProvider extends AWSCredentialsProviderChain(
-  new ProfileCredentialsProvider("identity"),
-  DefaultAWSCredentialsProviderChain.getInstance())
+object NewsletterSQSAWSCredentialProvider {
+
+  val credentialsProviderV2: AwsCredentialsProviderV2 = ProfileCredentialsProviderV2.create("identity")
+  val credentialsProviderV1: NewsletterSQSAWSCredentialProvider = new NewsletterSQSAWSCredentialProvider()
+
+  class NewsletterSQSAWSCredentialProvider extends AWSCredentialsProviderChain(
+    new ProfileCredentialsProvider("identity"),
+    DefaultAWSCredentialsProviderChain.getInstance())
+
+}

--- a/src/main/scala/com/gu/newsletterlistcleanse/NewsletterConfig.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/NewsletterConfig.scala
@@ -1,8 +1,9 @@
 package com.gu.newsletterlistcleanse
 
-import com.amazonaws.auth.AWSCredentialsProvider
 import com.gu.{AppIdentity, AwsIdentity}
 import com.gu.conf.{ConfigurationLoader, SSMConfigurationLocation}
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+
 import scala.collection.JavaConverters._
 
 case class NewsletterConfig(
@@ -17,7 +18,7 @@ case class NewsletterConfig(
 )
 
 object NewsletterConfig {
-  def load(credentialProvider: AWSCredentialsProvider): NewsletterConfig = {
+  def load(credentialProvider: AwsCredentialsProvider): NewsletterConfig = {
     val identity = AppIdentity.whoAmI(defaultAppName = "newsletter-list-cleanse", credentialProvider)
     val config = ConfigurationLoader.load(identity, credentialProvider) {
       case identity: AwsIdentity => SSMConfigurationLocation(s"/${identity.stack}/${identity.app}/${identity.stage}")


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
In this PR I am bumping the ssm library version to one that now available. I have also removed the reference to bintray now that service has been sunset.

As part of this, it was required to update the AWS Credentials to use a combination of their V1 & V2 SDKs. This was due to the version bump in our ` simple-configuration-ssm` library.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
`sbt compile`, previous attempts would fail as you would be unable to resolve the dependency.

Then dryRun the application and test again the BrazeQC environment.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
