### PR TITLE
Add new newsletter's cut off dates

### DIFF
--- a/src/main/scala/com/gu/newsletterlistcleanse/models/Newsletters.scala
+++ b/src/main/scala/com/gu/newsletterlistcleanse/models/Newsletters.scala
@@ -59,6 +59,8 @@ object Newsletters {
     "Editorial_TeacherNetwork" -> 13,
     "Editorial_DesignReview" -> 7,
     "Editorial_AustraliaUSelection" -> 61,
+    "Editorial_Tokyo2020DailyBriefing" -> 94,
+    "Editorial_TechScape" -> 13,
     // "Editorial_WeekendPapers" -> 94, => Marketing
     // "Editorial_OFM" -> 94, => Marketing
     // "MK_FrontPage" -> 94, => Marketing


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We have recently added some new newsletters and have to enforce the unsubscribe cut offs.
 
In this PR we are adding two newsletters, TechScape & Tokyo 2020 Daily Briefing. 


## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

The cut off dates are stipulated in the request for the initial mapping.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
